### PR TITLE
docs: add community guidelines, roadmap docs, and issue planning artifacts

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,57 @@
+# Code of Conduct
+
+## Our commitment
+
+Filament Logger is committed to providing a welcoming, respectful, and harassment-free experience for everyone participating in the project.
+
+We want contributors, users, and maintainers to feel safe asking questions, sharing ideas, reporting issues, and collaborating in public.
+
+## Expected behavior
+
+Examples of behavior that help create a positive environment include:
+
+- Being respectful and constructive in discussions, reviews, and issues.
+- Assuming good intent and responding with patience.
+- Giving feedback that is specific, helpful, and professional.
+- Being welcoming to contributors with different backgrounds and experience levels.
+- Focusing on what is best for the project and community.
+
+## Unacceptable behavior
+
+Examples of unacceptable behavior include:
+
+- Harassment, intimidation, or discriminatory language or behavior.
+- Personal attacks, insults, or trolling.
+- Publishing private information without explicit permission.
+- Repeatedly derailing discussions or acting in bad faith.
+- Any conduct that would reasonably make others feel unsafe or unwelcome.
+
+## Scope
+
+This Code of Conduct applies to project spaces, including:
+
+- GitHub issues
+- pull requests
+- discussions and reviews
+- other public or private project communication led by maintainers
+
+## Reporting
+
+If you experience or witness behavior that violates this Code of Conduct, please report it privately to the maintainer at `dgreen03@gmail.com`.
+
+Please include as much relevant context as you can, such as links, screenshots, or a short description of what happened.
+
+## Enforcement
+
+Project maintainers may take any action they deem appropriate in response to unacceptable behavior, including:
+
+- requesting a change in behavior
+- removing comments or content
+- temporarily restricting participation
+- banning someone from the project community
+
+All reports will be reviewed as fairly and promptly as possible.
+
+## Attribution
+
+This document is inspired by the Contributor Covenant and adapted for this project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing
+
+Thanks for your interest in contributing to Filament Logger.
+
+This project is a maintained fork of the original package by Z3d0X, and contributions are welcome across code, docs, tests, design, and issue triage.
+
+Please read this guide before opening a pull request.
+
+## Ground rules
+
+- Be respectful and constructive in all interactions.
+- Follow the guidance in [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md).
+- Keep `1.x` changes backward-compatible unless maintainers explicitly decide otherwise.
+- Prefer small, focused pull requests over large mixed changes.
+
+## Before you start
+
+- Search existing issues before opening a new one.
+- Use the issue form for bugs, features, documentation, or maintenance work.
+- Review [ROADMAP.md](./ROADMAP.md) and [TODO.md](./TODO.md) if you want to work on planned `1.x` improvements.
+- If you want to work on an existing issue, leave a comment so effort does not overlap unnecessarily.
+
+## Security issues
+
+Please do not open public issues for sensitive security problems.
+
+Use the project's security reporting channel instead.
+
+## Local setup
+
+Install dependencies:
+
+```bash
+composer install
+npm install
+```
+
+Useful commands:
+
+```bash
+composer validate --strict
+vendor/bin/pest
+vendor/bin/phpstan analyse --memory-limit=512M
+npm run docs:build
+```
+
+## Pull request expectations
+
+When opening a pull request:
+
+- keep the scope focused
+- include or update tests when behavior changes
+- update docs when user-facing behavior or configuration changes
+- make sure the relevant quality checks pass locally
+- write a clear title and description that explain the change
+
+If your change affects package behavior, please also note any upgrade or migration impact in the PR description.
+
+## Coding guidelines
+
+- Follow the existing project structure and naming conventions.
+- Prefer clear, maintainable code over clever abstractions.
+- Keep compatibility across supported Filament and Laravel versions in mind.
+- Avoid introducing breaking changes during the `1.x` series unless they are explicitly approved.
+
+## Documentation changes
+
+Documentation contributions are welcome.
+
+If you update docs:
+
+- keep examples accurate and copyable
+- run `npm run docs:build`
+- make sure links and navigation still work as expected
+
+## Release notes and roadmap
+
+Release notes are managed by maintainers during the release process, but PRs should still provide enough context to write clear changelog entries later.
+
+If your work changes roadmap direction or adds a meaningful new capability, mention that in the PR so maintainers can keep [ROADMAP.md](./ROADMAP.md) current.
+
+## Questions
+
+If you are unsure whether something is worth working on, open an issue first. That is usually the fastest way to align on scope and direction.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ See [CHANGELOG](CHANGELOG.md) for recent changes.
 
 ## Contributing
 
-See [CONTRIBUTING](https://github.com/spatie/.github/blob/main/CONTRIBUTING.md) for contribution guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines and [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) for community expectations.
 
 ## Security
 


### PR DESCRIPTION
## Summary

This PR improves the project's contributor-facing and planning documentation.

It adds project-specific community guidelines, publishes the roadmap in the docs site, and updates the public docs navigation so users see the roadmap instead of maintainer-only release workflow docs.

## What's included

- add `CODE_OF_CONDUCT.md`
- add `CONTRIBUTING.md`
- add `ROADMAP.md`
- add `docs/roadmap.md`
- keep `TODO.md` as an internal 1.x backlog
- update `docs/.vitepress/config.mjs` to surface the roadmap in the docs sidebar
- update `docs/index.md` to include the roadmap in the main documentation flow
- update `README.md` to link to the roadmap, contributing guide, and code of conduct

## Notes

- the public docs now surface the roadmap instead of the maintainer-focused releasing guide
- the releasing guide still exists in the repo, it is just no longer promoted in the public docs navigation
- the roadmap is intended as the public-facing 1.x direction, while `TODO.md` remains the internal backlog

## Validation

- `npm run docs:build`
- `git diff --check`
