### PR TITLE
fix: register activity dashboard widgets as Livewire components

### DIFF
--- a/src/FilamentLoggerServiceProvider.php
+++ b/src/FilamentLoggerServiceProvider.php
@@ -94,7 +94,9 @@ class FilamentLoggerServiceProvider extends PackageServiceProvider
     {
         parent::packageBooted();
 
-        $this->registerWidgetComponents();
+        $this->app->booted(function (): void {
+            $this->registerWidgetComponents();
+        });
 
         if (config('filament-logger.resources.enabled', true)) {
             $exceptResources = [...config('filament-logger.resources.exclude'), config('filament-logger.activity_resource')];

--- a/src/FilamentLoggerServiceProvider.php
+++ b/src/FilamentLoggerServiceProvider.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Events\NotificationFailed;
 use Illuminate\Notifications\Events\NotificationSent;
 use Illuminate\Support\Facades\Event;
+use Livewire\Livewire;
 use MrAdder\FilamentLogger\FilamentLogger as FilamentLoggerManager;
 use MrAdder\FilamentLogger\Commands\PruneActivitiesCommand;
 use MrAdder\FilamentLogger\Loggers\ResourceLogger;
@@ -22,6 +23,11 @@ use MrAdder\FilamentLogger\Support\ActivityExporter;
 use MrAdder\FilamentLogger\Support\ActivityRiskResolver;
 use MrAdder\FilamentLogger\Support\ObserverRegistrar;
 use MrAdder\FilamentLogger\Support\ReplicationContextStore;
+use MrAdder\FilamentLogger\Widgets\ActivityOverviewWidget;
+use MrAdder\FilamentLogger\Widgets\ActivityTrendChartWidget;
+use MrAdder\FilamentLogger\Widgets\HighRiskActionsChartWidget;
+use MrAdder\FilamentLogger\Widgets\TopEventsChartWidget;
+use MrAdder\FilamentLogger\Widgets\TopUsersChartWidget;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -87,6 +93,8 @@ class FilamentLoggerServiceProvider extends PackageServiceProvider
     public function packageBooted(): void
     {
         parent::packageBooted();
+
+        $this->registerWidgetComponents();
 
         if (config('filament-logger.resources.enabled', true)) {
             $exceptResources = [...config('filament-logger.resources.exclude'), config('filament-logger.activity_resource')];
@@ -178,5 +186,22 @@ class FilamentLoggerServiceProvider extends PackageServiceProvider
         }
 
         return null;
+    }
+
+    protected function registerWidgetComponents(): void
+    {
+        $components = [
+            'mr-adder.filament-logger.widgets.activity-overview-widget' => ActivityOverviewWidget::class,
+            'mr-adder.filament-logger.widgets.activity-trend-chart-widget' => ActivityTrendChartWidget::class,
+            'mr-adder.filament-logger.widgets.top-users-chart-widget' => TopUsersChartWidget::class,
+            'mr-adder.filament-logger.widgets.top-events-chart-widget' => TopEventsChartWidget::class,
+            'mr-adder.filament-logger.widgets.high-risk-actions-chart-widget' => HighRiskActionsChartWidget::class,
+        ];
+
+        foreach ($components as $name => $componentClass) {
+            if (class_exists($componentClass)) {
+                Livewire::component($name, $componentClass);
+            }
+        }
     }
 }

--- a/src/FilamentLoggerServiceProvider.php
+++ b/src/FilamentLoggerServiceProvider.php
@@ -94,6 +94,8 @@ class FilamentLoggerServiceProvider extends PackageServiceProvider
     {
         parent::packageBooted();
 
+        $this->registerWidgetComponents();
+
         $this->app->booted(function (): void {
             $this->registerWidgetComponents();
         });

--- a/tests/Feature/DashboardWidgetsRegistrationTest.php
+++ b/tests/Feature/DashboardWidgetsRegistrationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Livewire\Livewire;
 use MrAdder\FilamentLogger\Widgets\ActivityOverviewWidget;
 use MrAdder\FilamentLogger\Widgets\ActivityTrendChartWidget;
 use MrAdder\FilamentLogger\Widgets\HighRiskActionsChartWidget;
@@ -7,11 +8,46 @@ use MrAdder\FilamentLogger\Widgets\TopEventsChartWidget;
 use MrAdder\FilamentLogger\Widgets\TopUsersChartWidget;
 
 it('registers dashboard widgets as livewire components', function () {
-    $resolver = static fn (string $alias): ?string => app('livewire.finder')->resolveClassComponentClassName($alias);
+    $resolver = static function (string $alias): ?string {
+        $livewire = Livewire::getFacadeRoot();
 
-    expect($resolver('mr-adder.filament-logger.widgets.activity-overview-widget'))->toBe(ActivityOverviewWidget::class)
-        ->and($resolver('mr-adder.filament-logger.widgets.activity-trend-chart-widget'))->toBe(ActivityTrendChartWidget::class)
-        ->and($resolver('mr-adder.filament-logger.widgets.top-users-chart-widget'))->toBe(TopUsersChartWidget::class)
-        ->and($resolver('mr-adder.filament-logger.widgets.top-events-chart-widget'))->toBe(TopEventsChartWidget::class)
-        ->and($resolver('mr-adder.filament-logger.widgets.high-risk-actions-chart-widget'))->toBe(HighRiskActionsChartWidget::class);
+        if (method_exists($livewire, 'new')) {
+            try {
+                return get_class(Livewire::new($alias));
+            } catch (\Throwable) {
+                return null;
+            }
+        }
+
+        if (method_exists($livewire, 'exists') && Livewire::exists($alias)) {
+            return '__registered__';
+        }
+
+        if (method_exists($livewire, 'isDiscoverable') && Livewire::isDiscoverable($alias)) {
+            return '__registered__';
+        }
+
+        return null;
+    };
+
+    expect($resolver('mr-adder.filament-logger.widgets.activity-overview-widget'))->toBeIn([
+        ActivityOverviewWidget::class,
+        '__registered__',
+    ])
+        ->and($resolver('mr-adder.filament-logger.widgets.activity-trend-chart-widget'))->toBeIn([
+            ActivityTrendChartWidget::class,
+            '__registered__',
+        ])
+        ->and($resolver('mr-adder.filament-logger.widgets.top-users-chart-widget'))->toBeIn([
+            TopUsersChartWidget::class,
+            '__registered__',
+        ])
+        ->and($resolver('mr-adder.filament-logger.widgets.top-events-chart-widget'))->toBeIn([
+            TopEventsChartWidget::class,
+            '__registered__',
+        ])
+        ->and($resolver('mr-adder.filament-logger.widgets.high-risk-actions-chart-widget'))->toBeIn([
+            HighRiskActionsChartWidget::class,
+            '__registered__',
+        ]);
 });

--- a/tests/Feature/DashboardWidgetsRegistrationTest.php
+++ b/tests/Feature/DashboardWidgetsRegistrationTest.php
@@ -3,9 +3,17 @@
 use Livewire\Livewire;
 
 it('registers dashboard widgets as livewire components', function () {
-    expect(Livewire::exists('mr-adder.filament-logger.widgets.activity-overview-widget'))->toBeTrue()
-        ->and(Livewire::exists('mr-adder.filament-logger.widgets.activity-trend-chart-widget'))->toBeTrue()
-        ->and(Livewire::exists('mr-adder.filament-logger.widgets.top-users-chart-widget'))->toBeTrue()
-        ->and(Livewire::exists('mr-adder.filament-logger.widgets.top-events-chart-widget'))->toBeTrue()
-        ->and(Livewire::exists('mr-adder.filament-logger.widgets.high-risk-actions-chart-widget'))->toBeTrue();
+    $isRegistered = static function (string $alias): bool {
+        if (method_exists(Livewire::getFacadeRoot(), 'exists')) {
+            return Livewire::exists($alias);
+        }
+
+        return Livewire::isDiscoverable($alias);
+    };
+
+    expect($isRegistered('mr-adder.filament-logger.widgets.activity-overview-widget'))->toBeTrue()
+        ->and($isRegistered('mr-adder.filament-logger.widgets.activity-trend-chart-widget'))->toBeTrue()
+        ->and($isRegistered('mr-adder.filament-logger.widgets.top-users-chart-widget'))->toBeTrue()
+        ->and($isRegistered('mr-adder.filament-logger.widgets.top-events-chart-widget'))->toBeTrue()
+        ->and($isRegistered('mr-adder.filament-logger.widgets.high-risk-actions-chart-widget'))->toBeTrue();
 });

--- a/tests/Feature/DashboardWidgetsRegistrationTest.php
+++ b/tests/Feature/DashboardWidgetsRegistrationTest.php
@@ -1,19 +1,17 @@
 <?php
 
-use Livewire\Livewire;
+use MrAdder\FilamentLogger\Widgets\ActivityOverviewWidget;
+use MrAdder\FilamentLogger\Widgets\ActivityTrendChartWidget;
+use MrAdder\FilamentLogger\Widgets\HighRiskActionsChartWidget;
+use MrAdder\FilamentLogger\Widgets\TopEventsChartWidget;
+use MrAdder\FilamentLogger\Widgets\TopUsersChartWidget;
 
 it('registers dashboard widgets as livewire components', function () {
-    $isRegistered = static function (string $alias): bool {
-        if (method_exists(Livewire::getFacadeRoot(), 'exists')) {
-            return Livewire::exists($alias);
-        }
+    $resolver = static fn (string $alias): ?string => app('livewire.finder')->resolveClassComponentClassName($alias);
 
-        return Livewire::isDiscoverable($alias);
-    };
-
-    expect($isRegistered('mr-adder.filament-logger.widgets.activity-overview-widget'))->toBeTrue()
-        ->and($isRegistered('mr-adder.filament-logger.widgets.activity-trend-chart-widget'))->toBeTrue()
-        ->and($isRegistered('mr-adder.filament-logger.widgets.top-users-chart-widget'))->toBeTrue()
-        ->and($isRegistered('mr-adder.filament-logger.widgets.top-events-chart-widget'))->toBeTrue()
-        ->and($isRegistered('mr-adder.filament-logger.widgets.high-risk-actions-chart-widget'))->toBeTrue();
+    expect($resolver('mr-adder.filament-logger.widgets.activity-overview-widget'))->toBe(ActivityOverviewWidget::class)
+        ->and($resolver('mr-adder.filament-logger.widgets.activity-trend-chart-widget'))->toBe(ActivityTrendChartWidget::class)
+        ->and($resolver('mr-adder.filament-logger.widgets.top-users-chart-widget'))->toBe(TopUsersChartWidget::class)
+        ->and($resolver('mr-adder.filament-logger.widgets.top-events-chart-widget'))->toBe(TopEventsChartWidget::class)
+        ->and($resolver('mr-adder.filament-logger.widgets.high-risk-actions-chart-widget'))->toBe(HighRiskActionsChartWidget::class);
 });

--- a/tests/Feature/DashboardWidgetsRegistrationTest.php
+++ b/tests/Feature/DashboardWidgetsRegistrationTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use Livewire\Livewire;
+
+it('registers dashboard widgets as livewire components', function () {
+    expect(Livewire::exists('mr-adder.filament-logger.widgets.activity-overview-widget'))->toBeTrue()
+        ->and(Livewire::exists('mr-adder.filament-logger.widgets.activity-trend-chart-widget'))->toBeTrue()
+        ->and(Livewire::exists('mr-adder.filament-logger.widgets.top-users-chart-widget'))->toBeTrue()
+        ->and(Livewire::exists('mr-adder.filament-logger.widgets.top-events-chart-widget'))->toBeTrue()
+        ->and(Livewire::exists('mr-adder.filament-logger.widgets.high-risk-actions-chart-widget'))->toBeTrue();
+});


### PR DESCRIPTION
Fixes #35 

## Summary

- Fixes missing Livewire widget component resolution on the activity logs page.
- Ensures Filament Logger dashboard widgets are auto-registered by the package service provider, so app-level manual `Livewire::component(...)` registration is no longer required.

## Changes

- Added package-level Livewire component registration for:
  - `activity-overview-widget`
  - `activity-trend-chart-widget`
  - `top-users-chart-widget`
  - `top-events-chart-widget`
  - `high-risk-actions-chart-widget`
- Added a regression test to verify those widget aliases are registered and discoverable.

## Testing

- `vendor\bin\pest tests\Feature\DashboardWidgetsRegistrationTest.php`
- Manual smoke check:
  - open `/admin/activity-logs`
  - verify dashboard widgets render without `Unable to find component` errors

## Screenshots

- N/A (optional: include activity page screenshot after smoke test)

## Checklist

- [x] Linked the related issue, or explained why there is no linked issue
- [x] Updated documentation or configuration where needed
- [x] Added or updated tests where needed
- [x] Verified the relevant checks locally
- [x] Noted any breaking changes or follow-up work below

## Breaking Changes / Follow-Up

- None