### PR TITLE
feat: add Laravel 13 support across package constraints, CI, and docs

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -71,15 +71,33 @@ jobs:
             filament: '^4.3.1'
             stability: prefer-stable
           - os: ubuntu-latest
+            php: '8.3'
+            laravel: '13.*'
+            testbench: '11.*'
+            filament: '^4.3.1'
+            stability: prefer-stable
+          - os: ubuntu-latest
             php: '8.2'
             laravel: '12.*'
             testbench: '10.*'
             filament: '5.*'
             stability: prefer-lowest
           - os: ubuntu-latest
+            php: '8.3'
+            laravel: '13.*'
+            testbench: '11.*'
+            filament: '5.*'
+            stability: prefer-lowest
+          - os: ubuntu-latest
             php: '8.2'
             laravel: '12.*'
             testbench: '10.*'
+            filament: '5.*'
+            stability: prefer-stable
+          - os: ubuntu-latest
+            php: '8.3'
+            laravel: '13.*'
+            testbench: '11.*'
             filament: '5.*'
             stability: prefer-stable
           - os: ubuntu-latest
@@ -92,6 +110,12 @@ jobs:
             php: '8.4'
             laravel: '12.*'
             testbench: '10.*'
+            filament: '5.*'
+            stability: prefer-stable
+          - os: windows-latest
+            php: '8.5'
+            laravel: '13.*'
+            testbench: '11.*'
             filament: '5.*'
             stability: prefer-stable
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Use it when you need to:
 |---|---|
 | PHP | `^8.2` |
 | Filament | `^3.0`, `^4.3.1`, or `^5.0` |
-| Laravel contracts | `^11.0` or `^12.0` |
+| Laravel contracts | `^11.0`, `^12.0`, or `^13.0` |
 
 Filament 4 support starts at `4.3.1` because earlier `4.x` releases were affected by an upstream security issue fixed in `4.3.1`. See the [Filament security advisory](https://github.com/filamentphp/filament/security/advisories/GHSA-pvcv-q3q7-266g) and the [v4.3.1 release notes](https://github.com/filamentphp/filament/releases/tag/v4.3.1).
 

--- a/composer.json
+++ b/composer.json
@@ -39,14 +39,14 @@
     "require": {
         "php": "^8.2",
         "filament/filament": "^3.0 || ^4.3.1 || ^5.0",
-        "illuminate/contracts": "^11.0 | ^12.0",
+        "illuminate/contracts": "^11.0 | ^12.0 | ^13.0",
         "spatie/laravel-activitylog": "^4.5",
         "spatie/laravel-package-tools": "^1.13.5"
     },
     "require-dev": {
         "larastan/larastan": "^3.9",
-        "nunomaduro/collision": "^8.0 | ^9.0",
-        "orchestra/testbench": "^9.0 | ^10.0",
+        "nunomaduro/collision": "^8.0 | ^9.0 | ^10.0",
+        "orchestra/testbench": "^9.0 | ^10.0 | ^11.0",
         "pestphp/pest": "^3.7 | ^4.0",
         "pestphp/pest-plugin-laravel": "^3.1 | ^4.0",
         "phpstan/extension-installer": "^1.1",

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@
 |---|---|
 | PHP | `^8.2` |
 | Filament | `^3.0`, `^4.3.1`, or `^5.0` |
-| Laravel contracts | `^11.0` or `^12.0` |
+| Laravel contracts | `^11.0`, `^12.0`, or `^13.0` |
 
 Filament 4 support starts at `4.3.1` because earlier `4.x` releases were affected by an upstream security issue fixed in `4.3.1`. See the [Filament security advisory](https://github.com/filamentphp/filament/security/advisories/GHSA-pvcv-q3q7-266g) and the [v4.3.1 release notes](https://github.com/filamentphp/filament/releases/tag/v4.3.1).
 


### PR DESCRIPTION
Closes #37 

## Summary

- Adds Laravel 13 compatibility to the package.
- Expands CI coverage to validate Laravel 13 support.
- Updates docs so the published requirements match supported versions.

## Changes

- Updated Composer constraints to include Laravel 13 support:
  - `illuminate/contracts` now includes `^13.0`
  - `orchestra/testbench` now includes `^11.0`
  - `nunomaduro/collision` now includes `^10.0`
- Expanded test workflow matrix with Laravel 13 + Testbench 11 jobs.
- Updated requirement tables in README and installation docs to include Laravel contracts `^13.0`.

## Testing

- Ran `composer validate --strict` in repo root.
- Ran `composer test` in repo root (all tests passing).

## Screenshots

- Not applicable (no UI changes).

## Checklist

- [x] Linked the related issue, or explained why there is no linked issue
- [x] Updated documentation or configuration where needed
- [x] Added or updated tests where needed
- [x] Verified the relevant checks locally
- [x] Noted any breaking changes or follow-up work below

## Breaking Changes / Follow-Up

- None