### PR TITLE
feat: add built-in review presets and dashboard drill-down links for activity investigations

### DIFF
--- a/config/filament-logger.php
+++ b/config/filament-logger.php
@@ -112,6 +112,26 @@ return [
                 'log_names' => ['Access'],
                 'events' => [\MrAdder\FilamentLogger\Support\ActivityEvents::FAILED_LOGIN, 'Lockout'],
             ],
+            'failed_logins' => [
+                'label' => 'Failed Logins',
+                'icon' => 'heroicon-o-exclamation-triangle',
+                'log_names' => ['Access'],
+                'events' => [\MrAdder\FilamentLogger\Support\ActivityEvents::FAILED_LOGIN],
+                'date_preset' => 'last_7_days',
+            ],
+            'destructive_recent' => [
+                'label' => 'Recent Destructive',
+                'icon' => 'heroicon-o-fire',
+                'events' => ['Deleted', \MrAdder\FilamentLogger\Support\ActivityEvents::FORCE_DELETED],
+                'date_preset' => 'last_7_days',
+            ],
+            'auth_anomalies' => [
+                'label' => 'Auth Anomalies',
+                'icon' => 'heroicon-o-finger-print',
+                'log_names' => ['Access'],
+                'events' => [\MrAdder\FilamentLogger\Support\ActivityEvents::FAILED_LOGIN, 'Lockout', 'Two Factor Recovery'],
+                'date_preset' => 'last_30_days',
+            ],
         ],
     ],
 

--- a/docs/activity-review.md
+++ b/docs/activity-review.md
@@ -40,6 +40,26 @@ Saved filters are configured as tabs on the list page:
             'log_names' => ['Access'],
             'events' => ['Failed Login', 'Lockout'],
         ],
+        'failed_logins' => [
+            'label' => 'Failed Logins',
+            'icon' => 'heroicon-o-exclamation-triangle',
+            'log_names' => ['Access'],
+            'events' => ['Failed Login'],
+            'date_preset' => 'last_7_days',
+        ],
+        'destructive_recent' => [
+            'label' => 'Recent Destructive',
+            'icon' => 'heroicon-o-fire',
+            'events' => ['Deleted', 'Force Deleted'],
+            'date_preset' => 'last_7_days',
+        ],
+        'auth_anomalies' => [
+            'label' => 'Auth Anomalies',
+            'icon' => 'heroicon-o-finger-print',
+            'log_names' => ['Access'],
+            'events' => ['Failed Login', 'Lockout', 'Two Factor Recovery'],
+            'date_preset' => 'last_30_days',
+        ],
     ],
 ],
 ```
@@ -112,6 +132,8 @@ The current widgets cover:
 - top users
 - top events
 - high-risk actions
+
+Widget stat cards and chart headings can be used as drill-down shortcuts into the activity review page. Each shortcut opens the resource with the matching saved preset tab active.
 
 ![Activity overview dashboard widgets](/art/activity-review-dashboard-widgets.png)
 

--- a/src/Support/ActivityFilterPresetManager.php
+++ b/src/Support/ActivityFilterPresetManager.php
@@ -33,6 +33,26 @@ class ActivityFilterPresetManager
                 'log_names' => [config('filament-logger.access.log_name')],
                 'events' => ['Failed Login', 'Lockout'],
             ],
+            'failed_logins' => [
+                'label' => 'Failed Logins',
+                'icon' => 'heroicon-o-exclamation-triangle',
+                'log_names' => [config('filament-logger.access.log_name')],
+                'events' => [ActivityEvents::FAILED_LOGIN],
+                'date_preset' => 'last_7_days',
+            ],
+            'destructive_recent' => [
+                'label' => 'Recent Destructive',
+                'icon' => 'heroicon-o-fire',
+                'events' => ['Deleted', ActivityEvents::FORCE_DELETED],
+                'date_preset' => 'last_7_days',
+            ],
+            'auth_anomalies' => [
+                'label' => 'Auth Anomalies',
+                'icon' => 'heroicon-o-finger-print',
+                'log_names' => [config('filament-logger.access.log_name')],
+                'events' => [ActivityEvents::FAILED_LOGIN, 'Lockout', 'Two Factor Recovery'],
+                'date_preset' => 'last_30_days',
+            ],
         ]);
     }
 

--- a/src/Support/ActivityReviewLink.php
+++ b/src/Support/ActivityReviewLink.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace MrAdder\FilamentLogger\Support;
+
+use Throwable;
+
+final class ActivityReviewLink
+{
+    public static function toSavedPreset(string $preset): ?string
+    {
+        $resource = config('filament-logger.activity_resource');
+
+        if (! is_string($resource) || ! class_exists($resource) || ! method_exists($resource, 'getUrl')) {
+            return null;
+        }
+
+        try {
+            return $resource::getUrl('index', ['activeTab' => $preset]);
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    private function __construct()
+    {
+    }
+}

--- a/src/Support/ActivityReviewLink.php
+++ b/src/Support/ActivityReviewLink.php
@@ -10,7 +10,7 @@ final class ActivityReviewLink
     {
         $resource = config('filament-logger.activity_resource');
 
-        if (! is_string($resource) || ! class_exists($resource) || ! method_exists($resource, 'getUrl')) {
+        if (! is_string($resource) || ! class_exists($resource) || ! is_callable([$resource, 'getUrl'])) {
             return null;
         }
 
@@ -23,5 +23,6 @@ final class ActivityReviewLink
 
     private function __construct()
     {
+        // This class only exposes static helpers and should not be instantiated.
     }
 }

--- a/src/Widgets/ActivityOverviewWidget.php
+++ b/src/Widgets/ActivityOverviewWidget.php
@@ -5,6 +5,7 @@ namespace MrAdder\FilamentLogger\Widgets;
 use Filament\Widgets\StatsOverviewWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use MrAdder\FilamentLogger\Support\ActivityAnalytics;
+use MrAdder\FilamentLogger\Support\ActivityReviewLink;
 
 class ActivityOverviewWidget extends StatsOverviewWidget
 {
@@ -17,18 +18,41 @@ class ActivityOverviewWidget extends StatsOverviewWidget
         $overview = app(ActivityAnalytics::class)->overview($this->days);
 
         return [
-            Stat::make('Total Activity', (string) $overview['total'])
-                ->description("Last {$this->days} days")
-                ->color('primary'),
-            Stat::make('High Risk', (string) $overview['high_risk'])
-                ->description('High-risk actions detected')
-                ->color('danger'),
-            Stat::make('Failed Logins', (string) $overview['failed_logins'])
-                ->description('Authentication failures')
-                ->color('warning'),
-            Stat::make('Unique Actors', (string) $overview['unique_actors'])
-                ->description('Distinct causers recorded')
-                ->color('success'),
+            $this->withDrillDown(
+                Stat::make('Total Activity', (string) $overview['total'])
+                    ->description("Last {$this->days} days")
+                    ->color('primary'),
+                'all',
+            ),
+            $this->withDrillDown(
+                Stat::make('High Risk', (string) $overview['high_risk'])
+                    ->description('High-risk actions detected')
+                    ->color('danger'),
+                'high_risk',
+            ),
+            $this->withDrillDown(
+                Stat::make('Failed Logins', (string) $overview['failed_logins'])
+                    ->description('Authentication failures')
+                    ->color('warning'),
+                'failed_logins',
+            ),
+            $this->withDrillDown(
+                Stat::make('Unique Actors', (string) $overview['unique_actors'])
+                    ->description('Distinct causers recorded')
+                    ->color('success'),
+                'all',
+            ),
         ];
+    }
+
+    protected function withDrillDown(Stat $stat, string $preset): Stat
+    {
+        $url = ActivityReviewLink::toSavedPreset($preset);
+
+        if (! $url) {
+            return $stat;
+        }
+
+        return $stat->url($url);
     }
 }

--- a/src/Widgets/ActivityTrendChartWidget.php
+++ b/src/Widgets/ActivityTrendChartWidget.php
@@ -4,12 +4,13 @@ namespace MrAdder\FilamentLogger\Widgets;
 
 use Filament\Widgets\ChartWidget;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Support\HtmlString;
 use MrAdder\FilamentLogger\Support\ActivityAnalytics;
-use MrAdder\FilamentLogger\Support\ActivityReviewLink;
+use MrAdder\FilamentLogger\Widgets\Concerns\HasActivityReviewDrillDownHeading;
 
 class ActivityTrendChartWidget extends ChartWidget
 {
+    use HasActivityReviewDrillDownHeading;
+
     public int $days = 30;
 
     protected function getData(): array
@@ -36,13 +37,6 @@ class ActivityTrendChartWidget extends ChartWidget
 
     public function getHeading(): string | Htmlable | null
     {
-        $heading = 'Activity Trend';
-        $url = ActivityReviewLink::toSavedPreset('all');
-
-        if (! $url) {
-            return $heading;
-        }
-
-        return new HtmlString('<a href="'.e($url).'">'.e($heading).'</a>');
+        return $this->activityReviewHeading('Activity Trend', 'all');
     }
 }

--- a/src/Widgets/ActivityTrendChartWidget.php
+++ b/src/Widgets/ActivityTrendChartWidget.php
@@ -4,7 +4,9 @@ namespace MrAdder\FilamentLogger\Widgets;
 
 use Filament\Widgets\ChartWidget;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HtmlString;
 use MrAdder\FilamentLogger\Support\ActivityAnalytics;
+use MrAdder\FilamentLogger\Support\ActivityReviewLink;
 
 class ActivityTrendChartWidget extends ChartWidget
 {
@@ -34,6 +36,13 @@ class ActivityTrendChartWidget extends ChartWidget
 
     public function getHeading(): string | Htmlable | null
     {
-        return 'Activity Trend';
+        $heading = 'Activity Trend';
+        $url = ActivityReviewLink::toSavedPreset('all');
+
+        if (! $url) {
+            return $heading;
+        }
+
+        return new HtmlString('<a href="'.e($url).'">'.e($heading).'</a>');
     }
 }

--- a/src/Widgets/Concerns/HasActivityReviewDrillDownHeading.php
+++ b/src/Widgets/Concerns/HasActivityReviewDrillDownHeading.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace MrAdder\FilamentLogger\Widgets\Concerns;
+
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HtmlString;
+use MrAdder\FilamentLogger\Support\ActivityReviewLink;
+
+trait HasActivityReviewDrillDownHeading
+{
+    protected function activityReviewHeading(string $heading, string $preset): string | Htmlable | null
+    {
+        $url = ActivityReviewLink::toSavedPreset($preset);
+
+        if (! $url) {
+            return $heading;
+        }
+
+        return new HtmlString('<a href="'.e($url).'">'.e($heading).'</a>');
+    }
+}

--- a/src/Widgets/HighRiskActionsChartWidget.php
+++ b/src/Widgets/HighRiskActionsChartWidget.php
@@ -4,7 +4,9 @@ namespace MrAdder\FilamentLogger\Widgets;
 
 use Filament\Widgets\ChartWidget;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HtmlString;
 use MrAdder\FilamentLogger\Support\ActivityAnalytics;
+use MrAdder\FilamentLogger\Support\ActivityReviewLink;
 
 class HighRiskActionsChartWidget extends ChartWidget
 {
@@ -39,6 +41,13 @@ class HighRiskActionsChartWidget extends ChartWidget
 
     public function getHeading(): string | Htmlable | null
     {
-        return 'High-Risk Actions';
+        $heading = 'High-Risk Actions';
+        $url = ActivityReviewLink::toSavedPreset('high_risk');
+
+        if (! $url) {
+            return $heading;
+        }
+
+        return new HtmlString('<a href="'.e($url).'">'.e($heading).'</a>');
     }
 }

--- a/src/Widgets/HighRiskActionsChartWidget.php
+++ b/src/Widgets/HighRiskActionsChartWidget.php
@@ -4,12 +4,13 @@ namespace MrAdder\FilamentLogger\Widgets;
 
 use Filament\Widgets\ChartWidget;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Support\HtmlString;
 use MrAdder\FilamentLogger\Support\ActivityAnalytics;
-use MrAdder\FilamentLogger\Support\ActivityReviewLink;
+use MrAdder\FilamentLogger\Widgets\Concerns\HasActivityReviewDrillDownHeading;
 
 class HighRiskActionsChartWidget extends ChartWidget
 {
+    use HasActivityReviewDrillDownHeading;
+
     public int $days = 30;
 
     public int $limit = 5;
@@ -41,13 +42,6 @@ class HighRiskActionsChartWidget extends ChartWidget
 
     public function getHeading(): string | Htmlable | null
     {
-        $heading = 'High-Risk Actions';
-        $url = ActivityReviewLink::toSavedPreset('high_risk');
-
-        if (! $url) {
-            return $heading;
-        }
-
-        return new HtmlString('<a href="'.e($url).'">'.e($heading).'</a>');
+        return $this->activityReviewHeading('High-Risk Actions', 'high_risk');
     }
 }

--- a/src/Widgets/TopEventsChartWidget.php
+++ b/src/Widgets/TopEventsChartWidget.php
@@ -4,12 +4,13 @@ namespace MrAdder\FilamentLogger\Widgets;
 
 use Filament\Widgets\ChartWidget;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Support\HtmlString;
 use MrAdder\FilamentLogger\Support\ActivityAnalytics;
-use MrAdder\FilamentLogger\Support\ActivityReviewLink;
+use MrAdder\FilamentLogger\Widgets\Concerns\HasActivityReviewDrillDownHeading;
 
 class TopEventsChartWidget extends ChartWidget
 {
+    use HasActivityReviewDrillDownHeading;
+
     public int $days = 30;
 
     public int $limit = 5;
@@ -41,13 +42,6 @@ class TopEventsChartWidget extends ChartWidget
 
     public function getHeading(): string | Htmlable | null
     {
-        $heading = 'Top Events';
-        $url = ActivityReviewLink::toSavedPreset('all');
-
-        if (! $url) {
-            return $heading;
-        }
-
-        return new HtmlString('<a href="'.e($url).'">'.e($heading).'</a>');
+        return $this->activityReviewHeading('Top Events', 'all');
     }
 }

--- a/src/Widgets/TopEventsChartWidget.php
+++ b/src/Widgets/TopEventsChartWidget.php
@@ -4,7 +4,9 @@ namespace MrAdder\FilamentLogger\Widgets;
 
 use Filament\Widgets\ChartWidget;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HtmlString;
 use MrAdder\FilamentLogger\Support\ActivityAnalytics;
+use MrAdder\FilamentLogger\Support\ActivityReviewLink;
 
 class TopEventsChartWidget extends ChartWidget
 {
@@ -39,6 +41,13 @@ class TopEventsChartWidget extends ChartWidget
 
     public function getHeading(): string | Htmlable | null
     {
-        return 'Top Events';
+        $heading = 'Top Events';
+        $url = ActivityReviewLink::toSavedPreset('all');
+
+        if (! $url) {
+            return $heading;
+        }
+
+        return new HtmlString('<a href="'.e($url).'">'.e($heading).'</a>');
     }
 }

--- a/src/Widgets/TopUsersChartWidget.php
+++ b/src/Widgets/TopUsersChartWidget.php
@@ -4,12 +4,13 @@ namespace MrAdder\FilamentLogger\Widgets;
 
 use Filament\Widgets\ChartWidget;
 use Illuminate\Contracts\Support\Htmlable;
-use Illuminate\Support\HtmlString;
 use MrAdder\FilamentLogger\Support\ActivityAnalytics;
-use MrAdder\FilamentLogger\Support\ActivityReviewLink;
+use MrAdder\FilamentLogger\Widgets\Concerns\HasActivityReviewDrillDownHeading;
 
 class TopUsersChartWidget extends ChartWidget
 {
+    use HasActivityReviewDrillDownHeading;
+
     public int $days = 30;
 
     public int $limit = 5;
@@ -41,13 +42,6 @@ class TopUsersChartWidget extends ChartWidget
 
     public function getHeading(): string | Htmlable | null
     {
-        $heading = 'Top Users';
-        $url = ActivityReviewLink::toSavedPreset('all');
-
-        if (! $url) {
-            return $heading;
-        }
-
-        return new HtmlString('<a href="'.e($url).'">'.e($heading).'</a>');
+        return $this->activityReviewHeading('Top Users', 'all');
     }
 }

--- a/src/Widgets/TopUsersChartWidget.php
+++ b/src/Widgets/TopUsersChartWidget.php
@@ -4,7 +4,9 @@ namespace MrAdder\FilamentLogger\Widgets;
 
 use Filament\Widgets\ChartWidget;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HtmlString;
 use MrAdder\FilamentLogger\Support\ActivityAnalytics;
+use MrAdder\FilamentLogger\Support\ActivityReviewLink;
 
 class TopUsersChartWidget extends ChartWidget
 {
@@ -39,6 +41,13 @@ class TopUsersChartWidget extends ChartWidget
 
     public function getHeading(): string | Htmlable | null
     {
-        return 'Top Users';
+        $heading = 'Top Users';
+        $url = ActivityReviewLink::toSavedPreset('all');
+
+        if (! $url) {
+            return $heading;
+        }
+
+        return new HtmlString('<a href="'.e($url).'">'.e($heading).'</a>');
     }
 }

--- a/tests/Feature/DashboardWidgetsRegistrationTest.php
+++ b/tests/Feature/DashboardWidgetsRegistrationTest.php
@@ -10,24 +10,22 @@ use MrAdder\FilamentLogger\Widgets\TopUsersChartWidget;
 it('registers dashboard widgets as livewire components', function () {
     $resolver = static function (string $alias): ?string {
         $livewire = Livewire::getFacadeRoot();
+        $resolved = null;
 
         if (method_exists($livewire, 'new')) {
             try {
-                return get_class(Livewire::new($alias));
+                $resolved = get_class(Livewire::new($alias));
             } catch (\Throwable) {
-                return null;
+                $resolved = null;
             }
+        } elseif (
+            (method_exists($livewire, 'exists') && Livewire::exists($alias))
+            || (method_exists($livewire, 'isDiscoverable') && Livewire::isDiscoverable($alias))
+        ) {
+            $resolved = '__registered__';
         }
 
-        if (method_exists($livewire, 'exists') && Livewire::exists($alias)) {
-            return '__registered__';
-        }
-
-        if (method_exists($livewire, 'isDiscoverable') && Livewire::isDiscoverable($alias)) {
-            return '__registered__';
-        }
-
-        return null;
+        return $resolved;
     };
 
     expect($resolver('mr-adder.filament-logger.widgets.activity-overview-widget'))->toBeIn([

--- a/tests/Unit/ActivityFilterPresetManagerTest.php
+++ b/tests/Unit/ActivityFilterPresetManagerTest.php
@@ -77,7 +77,7 @@ it('resolves and applies date presets', function () {
     Carbon::setTestNow();
 });
 
-it('applies the failed logins preset for auth anomaly review', function () {
+it('applies the failed_logins preset', function () {
     app(FilamentLogger::class)->log(
         event: ActivityEvents::FAILED_LOGIN,
         description: 'Failed login attempt for user',

--- a/tests/Unit/ActivityFilterPresetManagerTest.php
+++ b/tests/Unit/ActivityFilterPresetManagerTest.php
@@ -3,8 +3,23 @@
 use Illuminate\Support\Carbon;
 use MrAdder\FilamentLogger\FilamentLogger;
 use MrAdder\FilamentLogger\Support\ActivityDatePreset;
+use MrAdder\FilamentLogger\Support\ActivityEvents;
 use MrAdder\FilamentLogger\Support\ActivityFilterPresetManager;
 use Spatie\Activitylog\Models\Activity;
+
+it('provides additional built-in saved review presets', function () {
+    $saved = ActivityFilterPresetManager::saved();
+
+    expect($saved)->toHaveKeys([
+        'all',
+        'high_risk',
+        'destructive',
+        'auth_issues',
+        'failed_logins',
+        'destructive_recent',
+        'auth_anomalies',
+    ]);
+});
 
 it('applies saved filter presets to activity queries', function () {
     app(FilamentLogger::class)->log(
@@ -60,4 +75,33 @@ it('resolves and applies date presets', function () {
     expect($query->pluck('event')->all())->toBe(['Today Event']);
 
     Carbon::setTestNow();
+});
+
+it('applies the failed logins preset for auth anomaly review', function () {
+    app(FilamentLogger::class)->log(
+        event: ActivityEvents::FAILED_LOGIN,
+        description: 'Failed login attempt for user',
+        options: [
+            'logName' => config('filament-logger.access.log_name', 'Access'),
+            'anonymous' => true,
+            'createdAt' => now()->subHour(),
+        ],
+    );
+
+    app(FilamentLogger::class)->log(
+        event: 'Login',
+        description: 'Successful login',
+        options: [
+            'logName' => config('filament-logger.access.log_name', 'Access'),
+            'anonymous' => true,
+            'createdAt' => now()->subHour(),
+        ],
+    );
+
+    $query = ActivityFilterPresetManager::apply(
+        Activity::query(),
+        ActivityFilterPresetManager::saved()['failed_logins'],
+    );
+
+    expect($query->pluck('event')->all())->toBe([ActivityEvents::FAILED_LOGIN]);
 });

--- a/tests/Unit/ActivityReviewLinkTest.php
+++ b/tests/Unit/ActivityReviewLinkTest.php
@@ -7,10 +7,11 @@ use MrAdder\FilamentLogger\Widgets\TopEventsChartWidget;
 class ActivityReviewLinkFakeResource
 {
     /**
-     * @param  array<string, string>  $parameters
+     * @param  array<int, mixed>  $arguments
      */
-    public static function getUrl(string $name = 'index', array $parameters = []): string
+    public static function getUrl(...$arguments): string
     {
+        $parameters = is_array($arguments[1] ?? null) ? $arguments[1] : [];
         $activeTab = $parameters['activeTab'] ?? 'all';
 
         return 'https://example.test/activity?activeTab='.$activeTab;

--- a/tests/Unit/ActivityReviewLinkTest.php
+++ b/tests/Unit/ActivityReviewLinkTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use MrAdder\FilamentLogger\Support\ActivityReviewLink;
+use MrAdder\FilamentLogger\Widgets\HighRiskActionsChartWidget;
+use MrAdder\FilamentLogger\Widgets\TopEventsChartWidget;
+
+class ActivityReviewLinkFakeResource
+{
+    /**
+     * @param  array<string, string>  $parameters
+     */
+    public static function getUrl(string $name = 'index', array $parameters = []): string
+    {
+        $activeTab = $parameters['activeTab'] ?? 'all';
+
+        return 'https://example.test/activity?activeTab='.$activeTab;
+    }
+}
+
+it('builds activity resource links for saved presets', function () {
+    config()->set('filament-logger.activity_resource', ActivityReviewLinkFakeResource::class);
+
+    $url = ActivityReviewLink::toSavedPreset('high_risk');
+
+    expect($url)
+        ->toBeString()
+        ->toContain('activeTab=high_risk');
+});
+
+it('returns null when no activity resource is configured', function () {
+    config()->set('filament-logger.activity_resource', null);
+
+    expect(ActivityReviewLink::toSavedPreset('all'))->toBeNull();
+});
+
+it('renders chart headings with drill-down links', function () {
+    config()->set('filament-logger.activity_resource', ActivityReviewLinkFakeResource::class);
+
+    $highRiskHeading = (string) (new HighRiskActionsChartWidget())->getHeading();
+    $topEventsHeading = (string) (new TopEventsChartWidget())->getHeading();
+
+    expect($highRiskHeading)
+        ->toContain('activeTab=high_risk')
+        ->and($topEventsHeading)
+        ->toContain('activeTab=all');
+});


### PR DESCRIPTION
Closes #15 

## Summary

- Improves the activity review flow by adding more built-in saved presets for common audit investigations.
- Adds drill-down navigation from dashboard widgets into the activity resource with matching preset filters.
- Keeps behavior coherent across supported Filament versions by using shared resource URL generation and safe fallbacks.

## Changes

- Added new built-in saved presets:
  - `failed_logins`
  - `destructive_recent`
  - `auth_anomalies`
- Kept existing presets and extended both runtime fallback and published config defaults.
- Added dashboard drill-down links:
  - Overview stat cards now open matching filtered activity views.
  - Chart widget headings now link into the activity resource with the appropriate `activeTab`.
- Added a shared helper to generate activity-review links from preset keys with graceful handling when routes are unavailable.
- Updated activity review docs to describe new presets and widget drill-down behavior.
- Scope explicitly excludes playground changes.

## Testing

- Ran focused tests for preset and drill-down behavior:
  - `vendor/bin/pest tests/Unit/ActivityFilterPresetManagerTest.php tests/Unit/ActivityReviewLinkTest.php`
- Ran full suite regression:
  - `composer test`
- Verified all tests pass locally.

## Screenshots

- Not included in this PR (behavior-focused update; no new UI components).

## Checklist

- [x] Linked the related issue, or explained why there is no linked issue
- [x] Updated documentation or configuration where needed
- [x] Added or updated tests where needed
- [x] Verified the relevant checks locally
- [x] Noted any breaking changes or follow-up work below

## Breaking Changes / Follow-Up

- None.