### PR TITLE
feat: improve activity diff UX for large and nested payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_modules
 docs/.vitepress/cache
 docs/.vitepress/dist
 playground/
+.vscode/settings.json

--- a/resources/views/infolists/activity-diff.blade.php
+++ b/resources/views/infolists/activity-diff.blade.php
@@ -1,6 +1,7 @@
 @php
     $rows = $getState()['rows'] ?? [];
     $metadata = $getState()['metadata'] ?? [];
+    $groupedRows = collect($rows)->groupBy('group');
 @endphp
 
 @once
@@ -29,6 +30,24 @@
         .fi-in-activity-diff-row {
             display: grid;
             grid-template-columns: minmax(11rem, 1fr) minmax(0, 1.4fr) minmax(0, 1.4fr);
+        }
+
+        .fi-in-activity-diff-group {
+            grid-column: 1 / -1;
+            padding: 0.65rem 1rem;
+            border-top: 1px solid rgba(148, 163, 184, 0.16);
+            color: #64748b;
+            font-size: 0.75rem;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            background: rgba(248, 250, 252, 0.75);
+        }
+
+        .dark .fi-in-activity-diff-group {
+            border-top-color: rgba(255, 255, 255, 0.08);
+            color: #cbd5e1;
+            background: rgba(15, 23, 42, 0.6);
         }
 
         .fi-in-activity-diff-row + .fi-in-activity-diff-row {
@@ -129,6 +148,12 @@
             font-size: 0.875rem;
         }
 
+        .fi-in-activity-diff-summary-meta {
+            margin-left: 0.4rem;
+            color: #94a3b8;
+            font-size: 0.75rem;
+        }
+
         .dark .fi-in-activity-diff-summary {
             color: #cbd5e1;
         }
@@ -144,6 +169,23 @@
             border-radius: 0.85rem;
             background: #0f172a;
             color: #f8fafc;
+        }
+
+        .fi-in-activity-diff-path-parent {
+            display: block;
+            color: #64748b;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+
+        .fi-in-activity-diff-path-leaf {
+            display: block;
+            font-size: 0.875rem;
+            font-weight: 700;
+        }
+
+        .dark .fi-in-activity-diff-path-parent {
+            color: #94a3b8;
         }
 
         .fi-in-activity-diff-empty-state {
@@ -257,36 +299,52 @@
                     </div>
                 </div>
 
-                @forelse ($rows as $row)
-                    <div class="fi-in-activity-diff-row">
-                        <div
-                            class="fi-in-activity-diff-cell fi-in-activity-diff-field"
-                            data-label="{{ __('Field') }}"
-                        >
-                            {{ $row['field'] }}
+                @forelse ($groupedRows as $group => $rowsInGroup)
+                    @if ($groupedRows->count() > 1)
+                        <div class="fi-in-activity-diff-group">
+                            {{ \\Illuminate\\Support\\Str::headline((string) $group) }}
                         </div>
+                    @endif
 
-                        @foreach (['old', 'new'] as $column)
-                            @php($cell = $row[$column])
-
+                    @foreach ($rowsInGroup as $row)
+                        <div class="fi-in-activity-diff-row">
                             <div
-                                class="fi-in-activity-diff-cell fi-in-activity-diff-{{ $column }} {{ $cell['empty'] ? 'fi-in-activity-diff-empty' : '' }}"
-                                data-label="{{ __('filament-logger::filament-logger.resource.label.' . $column) }}"
+                                class="fi-in-activity-diff-cell fi-in-activity-diff-field"
+                                data-label="{{ __('Field') }}"
                             >
-                                @if ($cell['expandable'])
-                                    <details>
-                                        <summary class="fi-in-activity-diff-summary">
-                                            {{ $cell['summary'] }}
-                                        </summary>
-
-                                        <pre class="fi-in-activity-diff-code">{{ $cell['display'] }}</pre>
-                                    </details>
+                                @if ($row['is_nested'] ?? false)
+                                    <span class="fi-in-activity-diff-path-parent">{{ \\Illuminate\\Support\\Str::beforeLast($row['field'], '.') }}</span>
+                                    <span class="fi-in-activity-diff-path-leaf">{{ \\Illuminate\\Support\\Str::afterLast($row['field'], '.') }}</span>
                                 @else
-                                    <pre>{{ $cell['display'] }}</pre>
+                                    {{ $row['field'] }}
                                 @endif
                             </div>
-                        @endforeach
-                    </div>
+
+                            @foreach (['old', 'new'] as $column)
+                                @php($cell = $row[$column])
+
+                                <div
+                                    class="fi-in-activity-diff-cell fi-in-activity-diff-{{ $column }} {{ $cell['empty'] ? 'fi-in-activity-diff-empty' : '' }}"
+                                    data-label="{{ __('filament-logger::filament-logger.resource.label.' . $column) }}"
+                                >
+                                    @if ($cell['expandable'])
+                                        <details>
+                                            <summary class="fi-in-activity-diff-summary">
+                                                {{ $cell['summary'] }}
+                                                <span class="fi-in-activity-diff-summary-meta">
+                                                    {{ $cell['line_count'] ?? 1 }}L · {{ $cell['char_count'] ?? 0 }}C
+                                                </span>
+                                            </summary>
+
+                                            <pre class="fi-in-activity-diff-code">{{ $cell['display'] }}</pre>
+                                        </details>
+                                    @else
+                                        <pre>{{ $cell['display'] }}</pre>
+                                    @endif
+                                </div>
+                            @endforeach
+                        </div>
+                    @endforeach
                 @empty
                     <div class="fi-in-activity-diff-empty-state">
                         {{ __('No recorded field changes for this activity.') }}

--- a/src/Support/ActivityChangesFormatter.php
+++ b/src/Support/ActivityChangesFormatter.php
@@ -2,6 +2,7 @@
 
 namespace MrAdder\FilamentLogger\Support;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Spatie\Activitylog\Models\Activity;
@@ -21,9 +22,9 @@ class ActivityChangesFormatter
         }
 
         $properties = ActivityViewerPrivacy::sanitizeProperties($activity->properties ?? [], $activity);
-        $old = self::normalizeSection($properties['old'] ?? []);
-        $attributes = self::normalizeSection($properties['attributes'] ?? []);
-        $metadata = self::normalizeSection(collect($properties)->except(['old', 'attributes'])->all());
+        $old = self::flattenSection(self::normalizeSection($properties['old'] ?? []));
+        $attributes = self::flattenSection(self::normalizeSection($properties['attributes'] ?? []));
+        $metadata = self::flattenSection(self::normalizeSection(collect($properties)->except(['old', 'attributes'])->all()));
         $keys = collect(array_keys($old))
             ->merge(array_keys($attributes))
             ->unique()
@@ -34,13 +35,17 @@ class ActivityChangesFormatter
             'rows' => $keys
                 ->map(fn (string $key): array => [
                     'field' => $key,
-                    'old' => self::formatValue(data_get($old, $key), array_key_exists($key, $old)),
-                    'new' => self::formatValue(data_get($attributes, $key), array_key_exists($key, $attributes)),
+                    'group' => self::groupFromPath($key),
+                    'is_nested' => str_contains($key, '.'),
+                    'old' => self::formatValue($old[$key] ?? null, array_key_exists($key, $old)),
+                    'new' => self::formatValue($attributes[$key] ?? null, array_key_exists($key, $attributes)),
                 ])
                 ->all(),
             'metadata' => collect($metadata)
                 ->map(fn (mixed $value, string $key): array => [
                     'field' => $key,
+                    'group' => self::groupFromPath($key),
+                    'is_nested' => str_contains($key, '.'),
                     'value' => self::formatValue($value, true),
                 ])
                 ->values()
@@ -61,7 +66,84 @@ class ActivityChangesFormatter
     }
 
     /**
-     * @return array{display: string, summary: string, expandable: bool, empty: bool}
+     * @param  array<string, mixed>  $section
+     * @return array<string, mixed>
+     */
+    protected static function flattenSection(array $section, string $prefix = ''): array
+    {
+        $flattened = [];
+
+        foreach ($section as $key => $value) {
+            self::flattenEntry($flattened, $prefix, (string) $key, $value);
+        }
+
+        return $flattened;
+    }
+
+    /**
+     * @param  array<string, mixed>  $flattened
+     */
+    protected static function flattenEntry(array &$flattened, string $prefix, string $key, mixed $value): void
+    {
+        $path = $prefix === '' ? $key : $prefix.'.'.$key;
+        $value = self::normalizeFlattenValue($value);
+
+        if (! is_array($value) || $value === [] || self::shouldKeepListAsValue($value)) {
+            $flattened[$path] = $value;
+
+            return;
+        }
+
+        self::appendNestedValues($flattened, $path, $value);
+    }
+
+    protected static function normalizeFlattenValue(mixed $value): mixed
+    {
+        if ($value instanceof Collection) {
+            return $value->toArray();
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $value
+     */
+    protected static function shouldKeepListAsValue(array $value): bool
+    {
+        if (! Arr::isList($value)) {
+            return false;
+        }
+
+        return ! collect($value)->contains(fn (mixed $item): bool => is_array($item) || $item instanceof Collection);
+    }
+
+    /**
+     * @param  array<string, mixed>  $flattened
+     * @param  array<int|string, mixed>  $value
+     */
+    protected static function appendNestedValues(array &$flattened, string $path, array $value): void
+    {
+        $nested = self::flattenSection($value, $path);
+
+        if ($nested === []) {
+            $flattened[$path] = $value;
+
+            return;
+        }
+
+        foreach ($nested as $nestedPath => $nestedValue) {
+            $flattened[$nestedPath] = $nestedValue;
+        }
+    }
+
+    protected static function groupFromPath(string $path): string
+    {
+        return Str::before($path, '.');
+    }
+
+    /**
+     * @return array{display: string, summary: string, expandable: bool, empty: bool, line_count: int, char_count: int}
      */
     protected static function formatValue(mixed $value, bool $hasValue): array
     {
@@ -71,6 +153,8 @@ class ActivityChangesFormatter
                 'summary' => '-',
                 'expandable' => false,
                 'empty' => true,
+                'line_count' => 1,
+                'char_count' => 1,
             ];
         }
 
@@ -80,20 +164,34 @@ class ActivityChangesFormatter
                 'summary' => 'null',
                 'expandable' => false,
                 'empty' => false,
+                'line_count' => 1,
+                'char_count' => 4,
             ];
         }
 
         $display = self::stringify($value);
-        $summary = Str::of(str_replace(["\r\n", "\r", "\n"], ' ', $display))
+        $lineCount = substr_count($display, PHP_EOL) + 1;
+        $charCount = mb_strlen($display);
+        $collapseAfter = (int) config('filament-logger.diff.collapse_after', 120);
+        $summaryPreview = Str::of(str_replace(["\r\n", "\r", "\n"], ' ', $display))
             ->squish()
-            ->limit((int) config('filament-logger.diff.collapse_after', 120))
+            ->limit($collapseAfter)
             ->toString();
+        $expandable = str_contains($display, PHP_EOL) || ($charCount > $collapseAfter);
+
+        $summary = $summaryPreview;
+
+        if ($expandable) {
+            $summary .= ' · '.$lineCount.' lines';
+        }
 
         return [
             'display' => $display,
             'summary' => $summary,
-            'expandable' => str_contains($display, PHP_EOL) || (Str::length($display) > (int) config('filament-logger.diff.collapse_after', 120)),
+            'expandable' => $expandable,
             'empty' => false,
+            'line_count' => $lineCount,
+            'char_count' => $charCount,
         ];
     }
 

--- a/tests/Feature/DashboardWidgetsRegistrationTest.php
+++ b/tests/Feature/DashboardWidgetsRegistrationTest.php
@@ -10,24 +10,22 @@ use MrAdder\FilamentLogger\Widgets\TopUsersChartWidget;
 it('registers dashboard widgets as livewire components', function () {
     $resolver = static function (string $alias): ?string {
         $livewire = Livewire::getFacadeRoot();
+        $resolved = null;
 
         if (method_exists($livewire, 'new')) {
             try {
-                return get_class(Livewire::new($alias));
+                $resolved = get_class(Livewire::new($alias));
             } catch (\Throwable) {
-                return null;
+                $resolved = null;
             }
+        } elseif (
+            (method_exists($livewire, 'exists') && Livewire::exists($alias))
+            || (method_exists($livewire, 'isDiscoverable') && Livewire::isDiscoverable($alias))
+        ) {
+            $resolved = '__registered__';
         }
 
-        if (method_exists($livewire, 'exists') && Livewire::exists($alias)) {
-            return '__registered__';
-        }
-
-        if (method_exists($livewire, 'isDiscoverable') && Livewire::isDiscoverable($alias)) {
-            return '__registered__';
-        }
-
-        return null;
+        return $resolved;
     };
 
     expect($resolver('mr-adder.filament-logger.widgets.activity-overview-widget'))->toBeIn([

--- a/tests/Unit/ActivityChangesFormatterTest.php
+++ b/tests/Unit/ActivityChangesFormatterTest.php
@@ -72,6 +72,85 @@ it('shows stored sensitive values to viewers with sensitive data access', functi
         ->and($rows['ip_address']['new']['display'])->toBe(CHANGES_FORMATTER_NEW_IP);
 });
 
+it('flattens nested change payloads into readable field paths', function () {
+    $activity = new Activity();
+    $activity->forceFill([
+        'properties' => [
+            'old' => [
+                'profile' => [
+                    'settings' => [
+                        'timezone' => 'UTC',
+                        'locale' => 'en',
+                    ],
+                ],
+            ],
+            'attributes' => [
+                'profile' => [
+                    'settings' => [
+                        'timezone' => 'Africa/Johannesburg',
+                        'locale' => 'en',
+                    ],
+                ],
+            ],
+        ],
+    ]);
+
+    $formatted = ActivityChangesFormatter::for($activity);
+    $rows = collect($formatted['rows'])->keyBy('field');
+
+    expect($rows)->toHaveKeys([
+        'profile.settings.locale',
+        'profile.settings.timezone',
+    ])
+        ->and($rows['profile.settings.timezone']['is_nested'])->toBeTrue()
+        ->and($rows['profile.settings.timezone']['group'])->toBe('profile')
+        ->and($rows['profile.settings.timezone']['old']['display'])->toBe('UTC')
+        ->and($rows['profile.settings.timezone']['new']['display'])->toBe('Africa/Johannesburg');
+});
+
+it('marks large nested values as expandable with size metadata', function () {
+    config()->set('filament-logger.diff.collapse_after', 40);
+
+    $activity = new Activity();
+    $activity->forceFill([
+        'properties' => [
+            'old' => [
+                'payload' => [
+                    'tags' => [
+                        'security',
+                        'audit',
+                        'compliance',
+                        'investigation',
+                    ],
+                ],
+            ],
+            'attributes' => [
+                'payload' => [
+                    'tags' => [
+                        'security',
+                        'audit',
+                        'compliance',
+                        'investigation',
+                        'urgent',
+                    ],
+                ],
+            ],
+        ],
+    ]);
+
+    $formatted = ActivityChangesFormatter::for($activity);
+    $rows = collect($formatted['rows'])->keyBy('field');
+    $oldPayload = $rows['payload.tags']['old'];
+    $newPayload = $rows['payload.tags']['new'];
+
+    expect($oldPayload['expandable'])->toBeTrue()
+        ->and($newPayload['expandable'])->toBeTrue()
+        ->and($oldPayload['line_count'])->toBeGreaterThan(0)
+        ->and($newPayload['line_count'])->toBeGreaterThan(0)
+        ->and($newPayload['char_count'])->toBeGreaterThan($oldPayload['char_count'])
+        ->and($newPayload['summary'])->toContain('lines');
+});
+
 class AllowSensitiveActivityPolicy
 {
     public function viewSensitiveData(): bool


### PR DESCRIPTION
Closes #16 

## Summary

- Improves the activity detail diff experience for investigations with large, nested, or noisy payloads.
- Makes nested changes easier to scan by flattening deep structures into readable field paths.
- Adds clearer expand/collapse summaries with size context to reduce visual overload.

## Changes

- Updated formatter output to:
  - flatten nested `old` / `attributes` / metadata structures into dot-path fields
  - add grouping metadata for related fields
  - include `line_count` and `char_count` metadata for rendered values
  - preserve existing behavior for scalar, null, and redacted values
- Updated diff view rendering to:
  - group rows by top-level field context
  - display nested path parent/leaf more clearly
  - show compact summary metadata (lines/chars) for expandable values
- Added/updated tests for:
  - nested payload flattening behavior
  - large payload expandability and summary metadata
  - existing sensitive/redaction behavior compatibility
- Included small code-quality refactors requested during review (complexity/return-count/callable guard cleanups) without changing intended behavior.

## Testing

- Ran focused unit tests for formatter and diff behavior.
- Ran related feature tests for widget registration and review link behavior after review-driven refactors.
- Ran full test suite successfully (`composer test`).

## Screenshots

- Not included in this PR.

## Checklist

- [x] Linked the related issue, or explained why there is no linked issue
- [x] Updated documentation or configuration where needed
- [x] Added or updated tests where needed
- [x] Verified the relevant checks locally
- [x] Noted any breaking changes or follow-up work below

## Breaking Changes / Follow-Up

- None.