### PR TITLE
feat: add investigation playbooks for one-click filtered activity review

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,9 +19,6 @@ on:
       - 'art/**'
       - 'docs/**'
 
-permissions:
-  contents: read
-
 concurrency:
   group: run-tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -35,6 +32,8 @@ jobs:
     name: PHP ${{ matrix.php }} / Laravel ${{ matrix.laravel }} / Filament ${{ matrix.filament }} / ${{ matrix.stability }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 25
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false
@@ -160,6 +159,53 @@ jobs:
           composer require "filament/filament:${{ matrix.filament }}" --no-update
           composer require --dev "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-update
           composer update --${{ matrix.stability }} --prefer-dist --with-all-dependencies --no-progress
+
+      - name: Execute tests
+        run: vendor/bin/pest --no-coverage
+
+  laravel13-filament5-required:
+    name: Laravel 13 / Filament 5 Required Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: test
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@d59004228537ca90c8dca680592a08a675bf52b6
+        with:
+          php-version: '8.3'
+          extensions: none, curl, dom, fileinfo, intl, mbstring, openssl, pdo_sqlite, simplexml, sqlite, tokenizer, xml, xmlreader, xmlwriter, zip
+          tools: composer:v2
+          coverage: none
+
+      - name: Resolve Composer cache directory
+        id: composer-cache
+        shell: bash
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Composer downloads
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-8.3-laravel-13-testbench-11-filament-5-required-composer-${{ hashFiles('composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-php-8.3-laravel-13-testbench-11-filament-5-required-composer-
+            ${{ runner.os }}-php-8.3-composer-
+            ${{ runner.os }}-composer-
+
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Install Laravel 13 + Filament 5 dependencies
+        run: |
+          composer require "filament/filament:5.*" --no-update
+          composer require --dev "laravel/framework:13.*" "orchestra/testbench:11.*" --no-update
+          composer update --prefer-stable --prefer-dist --with-all-dependencies --no-progress
 
       - name: Execute tests
         run: vendor/bin/pest --no-coverage

--- a/config/filament-logger.php
+++ b/config/filament-logger.php
@@ -101,6 +101,12 @@ return [
             'preset' => 'auth_anomalies',
             'date_preset' => 'last_30_days',
         ],
+        'failed_logins' => [
+            'label' => 'Failed Logins',
+            'icon' => 'heroicon-o-exclamation-triangle',
+            'preset' => 'failed_logins',
+            'date_preset' => 'last_7_days',
+        ],
         'destructive_actions' => [
             'label' => 'Destructive Actions',
             'icon' => 'heroicon-o-fire',

--- a/config/filament-logger.php
+++ b/config/filament-logger.php
@@ -83,37 +83,7 @@ return [
         'top_limit' => 5,
     ],
 
-    'activity_playbooks' => [
-        'all_activity' => [
-            'label' => 'All Activity',
-            'icon' => 'heroicon-o-bars-3-bottom-left',
-            'preset' => 'all',
-        ],
-        'high_risk_incidents' => [
-            'label' => 'High Risk Incidents',
-            'icon' => 'heroicon-o-shield-exclamation',
-            'preset' => 'high_risk',
-            'date_preset' => 'last_30_days',
-        ],
-        'auth_anomalies' => [
-            'label' => 'Auth Anomalies',
-            'icon' => 'heroicon-o-finger-print',
-            'preset' => 'auth_anomalies',
-            'date_preset' => 'last_30_days',
-        ],
-        'failed_logins' => [
-            'label' => 'Failed Logins',
-            'icon' => 'heroicon-o-exclamation-triangle',
-            'preset' => 'failed_logins',
-            'date_preset' => 'last_7_days',
-        ],
-        'destructive_actions' => [
-            'label' => 'Destructive Actions',
-            'icon' => 'heroicon-o-fire',
-            'preset' => 'destructive_recent',
-            'date_preset' => 'last_7_days',
-        ],
-    ],
+    'activity_playbooks' => \MrAdder\FilamentLogger\Support\ActivityReviewPlaybookManager::DEFAULT_PLAYBOOKS,
 
     'activity_filters' => [
         'date_presets' => [

--- a/config/filament-logger.php
+++ b/config/filament-logger.php
@@ -83,6 +83,32 @@ return [
         'top_limit' => 5,
     ],
 
+    'activity_playbooks' => [
+        'all_activity' => [
+            'label' => 'All Activity',
+            'icon' => 'heroicon-o-bars-3-bottom-left',
+            'preset' => 'all',
+        ],
+        'high_risk_incidents' => [
+            'label' => 'High Risk Incidents',
+            'icon' => 'heroicon-o-shield-exclamation',
+            'preset' => 'high_risk',
+            'date_preset' => 'last_30_days',
+        ],
+        'auth_anomalies' => [
+            'label' => 'Auth Anomalies',
+            'icon' => 'heroicon-o-finger-print',
+            'preset' => 'auth_anomalies',
+            'date_preset' => 'last_30_days',
+        ],
+        'destructive_actions' => [
+            'label' => 'Destructive Actions',
+            'icon' => 'heroicon-o-fire',
+            'preset' => 'destructive_recent',
+            'date_preset' => 'last_7_days',
+        ],
+    ],
+
     'activity_filters' => [
         'date_presets' => [
             'today' => 'Today',

--- a/docs/activity-review.md
+++ b/docs/activity-review.md
@@ -135,6 +135,40 @@ The current widgets cover:
 
 Widget stat cards and chart headings can be used as drill-down shortcuts into the activity review page. Each shortcut opens the resource with the matching saved preset tab active.
 
+## Investigation Playbooks
+
+Playbooks provide one-click review paths by bundling a saved tab preset with an optional date preset:
+
+```php
+'activity_playbooks' => [
+    'all_activity' => [
+        'label' => 'All Activity',
+        'icon' => 'heroicon-o-bars-3-bottom-left',
+        'preset' => 'all',
+    ],
+    'high_risk_incidents' => [
+        'label' => 'High Risk Incidents',
+        'icon' => 'heroicon-o-shield-exclamation',
+        'preset' => 'high_risk',
+        'date_preset' => 'last_30_days',
+    ],
+    'auth_anomalies' => [
+        'label' => 'Auth Anomalies',
+        'icon' => 'heroicon-o-finger-print',
+        'preset' => 'auth_anomalies',
+        'date_preset' => 'last_30_days',
+    ],
+    'destructive_actions' => [
+        'label' => 'Destructive Actions',
+        'icon' => 'heroicon-o-fire',
+        'preset' => 'destructive_recent',
+        'date_preset' => 'last_7_days',
+    ],
+],
+```
+
+The Activity page header includes a **Playbooks** action group, and dashboard drill-down links use these playbooks to open coherent filtered review views.
+
 ![Activity overview dashboard widgets](/art/activity-review-dashboard-widgets.png)
 
 ## Retention and Pruning

--- a/docs/activity-review.md
+++ b/docs/activity-review.md
@@ -133,7 +133,7 @@ The current widgets cover:
 - top events
 - high-risk actions
 
-Widget stat cards and chart headings can be used as drill-down shortcuts into the activity review page. Each shortcut opens the resource with the matching saved preset tab active.
+Widget stat cards and chart headings can be used as drill-down shortcuts into the activity review page. Each shortcut opens the resource using a matching playbook, which applies the configured tab preset and optional date filter parameters.
 
 ## Investigation Playbooks
 
@@ -157,6 +157,12 @@ Playbooks provide one-click review paths by bundling a saved tab preset with an 
         'icon' => 'heroicon-o-finger-print',
         'preset' => 'auth_anomalies',
         'date_preset' => 'last_30_days',
+    ],
+    'failed_logins' => [
+        'label' => 'Failed Logins',
+        'icon' => 'heroicon-o-exclamation-triangle',
+        'preset' => 'failed_logins',
+        'date_preset' => 'last_7_days',
     ],
     'destructive_actions' => [
         'label' => 'Destructive Actions',

--- a/docs/activity-review.md
+++ b/docs/activity-review.md
@@ -167,6 +167,35 @@ Playbooks provide one-click review paths by bundling a saved tab preset with an 
 ],
 ```
 
+### Playbooks Quick Start
+
+1. Keep the default `activity_playbooks` config or add your own keys.
+2. Open the Activity resource and use the **Playbooks** header action.
+3. Click a playbook to open the matching review tab and date scope automatically.
+
+### Custom Playbook Example
+
+You can add a custom playbook for your own workflow:
+
+```php
+'activity_playbooks' => [
+    'sensitive_changes_last_24h' => [
+        'label' => 'Sensitive Changes (24h)',
+        'icon' => 'heroicon-o-key',
+        'preset' => 'high_risk',
+        'date_preset' => 'last_24_hours',
+    ],
+],
+```
+
+### Deep-Link Example
+
+Playbook links are resolved to Activity resource query parameters. Equivalent deep links can be built directly:
+
+```text
+/admin/activity-logs?activeTab=high_risk&tableFilters[created_at][preset]=last_30_days
+```
+
 The Activity page header includes a **Playbooks** action group, and dashboard drill-down links use these playbooks to open coherent filtered review views.
 
 ![Activity overview dashboard widgets](/art/activity-review-dashboard-widgets.png)

--- a/src/Resources/ActivityResource/Pages/BaseListActivities.php
+++ b/src/Resources/ActivityResource/Pages/BaseListActivities.php
@@ -7,6 +7,8 @@ use Filament\Actions\ActionGroup;
 use Filament\Resources\Pages\ListRecords;
 use MrAdder\FilamentLogger\Support\ActivityExporter;
 use MrAdder\FilamentLogger\Support\ActivityFilterPresetManager;
+use MrAdder\FilamentLogger\Support\ActivityReviewLink;
+use MrAdder\FilamentLogger\Support\ActivityReviewPlaybookManager;
 use MrAdder\FilamentLogger\Widgets\ActivityOverviewWidget;
 use MrAdder\FilamentLogger\Widgets\ActivityTrendChartWidget;
 use MrAdder\FilamentLogger\Widgets\HighRiskActionsChartWidget;
@@ -23,12 +25,36 @@ abstract class BaseListActivities extends ListRecords
 
     protected function getHeaderActions(): array
     {
-        if (! config('filament-logger.exports.enabled', true)) {
-            return [];
+        $actions = [];
+
+        $playbookActions = collect(ActivityReviewPlaybookManager::all())
+            ->map(function (array $playbook, string $key): ?Action {
+                $url = ActivityReviewLink::toPlaybook($key);
+
+                if (! $url) {
+                    return null;
+                }
+
+                return Action::make('playbook_'.$key)
+                    ->label((string) data_get($playbook, 'label', ActivityReviewPlaybookManager::label($key)))
+                    ->icon(data_get($playbook, 'icon'))
+                    ->url($url);
+            })
+            ->filter()
+            ->values()
+            ->all();
+
+        if ($playbookActions !== []) {
+            $actions[] = ActionGroup::make($playbookActions)
+                ->label('Playbooks')
+                ->icon('heroicon-o-book-open');
         }
 
-        return [
-            ActionGroup::make([
+        if (! config('filament-logger.exports.enabled', true)) {
+            return $actions;
+        }
+
+        $actions[] = ActionGroup::make([
                 Action::make('exportCsv')
                     ->label('Export CSV')
                     ->icon('heroicon-o-table-cells')
@@ -38,9 +64,10 @@ abstract class BaseListActivities extends ListRecords
                     ->icon('heroicon-o-code-bracket')
                     ->action(fn (): StreamedResponse => $this->exportJson()),
             ])
-                ->label('Export')
-                ->icon('heroicon-o-arrow-down-tray'),
-        ];
+            ->label('Export')
+            ->icon('heroicon-o-arrow-down-tray');
+
+        return $actions;
     }
 
     public function getTabs(): array

--- a/src/Support/ActivityReviewLink.php
+++ b/src/Support/ActivityReviewLink.php
@@ -8,6 +8,27 @@ final class ActivityReviewLink
 {
     public static function toSavedPreset(string $preset): ?string
     {
+        return self::toUrl([
+            'activeTab' => $preset,
+        ]);
+    }
+
+    public static function toPlaybook(string $playbook): ?string
+    {
+        $parameters = ActivityReviewPlaybookManager::toUrlParameters($playbook);
+
+        if ($parameters === []) {
+            return null;
+        }
+
+        return self::toUrl($parameters);
+    }
+
+    /**
+     * @param  array<string, mixed>  $parameters
+     */
+    protected static function toUrl(array $parameters): ?string
+    {
         $resource = config('filament-logger.activity_resource');
 
         if (! is_string($resource) || ! class_exists($resource) || ! is_callable([$resource, 'getUrl'])) {
@@ -15,7 +36,7 @@ final class ActivityReviewLink
         }
 
         try {
-            return $resource::getUrl('index', ['activeTab' => $preset]);
+            return $resource::getUrl('index', $parameters);
         } catch (Throwable) {
             return null;
         }

--- a/src/Support/ActivityReviewPlaybookManager.php
+++ b/src/Support/ActivityReviewPlaybookManager.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace MrAdder\FilamentLogger\Support;
+
+use Illuminate\Support\Str;
+
+class ActivityReviewPlaybookManager
+{
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function all(): array
+    {
+        return config('filament-logger.activity_playbooks', [
+            'all_activity' => [
+                'label' => 'All Activity',
+                'icon' => 'heroicon-o-bars-3-bottom-left',
+                'preset' => 'all',
+            ],
+            'high_risk_incidents' => [
+                'label' => 'High Risk Incidents',
+                'icon' => 'heroicon-o-shield-exclamation',
+                'preset' => 'high_risk',
+                'date_preset' => 'last_30_days',
+            ],
+            'auth_anomalies' => [
+                'label' => 'Auth Anomalies',
+                'icon' => 'heroicon-o-finger-print',
+                'preset' => 'auth_anomalies',
+                'date_preset' => 'last_30_days',
+            ],
+            'destructive_actions' => [
+                'label' => 'Destructive Actions',
+                'icon' => 'heroicon-o-fire',
+                'preset' => 'destructive_recent',
+                'date_preset' => 'last_7_days',
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public static function resolve(string $key): ?array
+    {
+        return self::all()[$key] ?? null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function toUrlParameters(string $key): array
+    {
+        $playbook = self::resolve($key);
+
+        if (! $playbook) {
+            return [];
+        }
+
+        $preset = (string) data_get($playbook, 'preset', 'all');
+        $datePreset = data_get($playbook, 'date_preset');
+        $parameters = [
+            'activeTab' => $preset,
+        ];
+
+        if (filled($datePreset)) {
+            $parameters['tableFilters'] = [
+                'created_at' => [
+                    'preset' => (string) $datePreset,
+                ],
+            ];
+        }
+
+        return $parameters;
+    }
+
+    public static function label(string $key): string
+    {
+        return (string) data_get(self::resolve($key), 'label', Str::headline($key));
+    }
+}

--- a/src/Support/ActivityReviewPlaybookManager.php
+++ b/src/Support/ActivityReviewPlaybookManager.php
@@ -7,41 +7,46 @@ use Illuminate\Support\Str;
 class ActivityReviewPlaybookManager
 {
     /**
+     * @var array<string, array<string, mixed>>
+     */
+    public const DEFAULT_PLAYBOOKS = [
+        'all_activity' => [
+            'label' => 'All Activity',
+            'icon' => 'heroicon-o-bars-3-bottom-left',
+            'preset' => 'all',
+        ],
+        'high_risk_incidents' => [
+            'label' => 'High Risk Incidents',
+            'icon' => 'heroicon-o-shield-exclamation',
+            'preset' => 'high_risk',
+            'date_preset' => 'last_30_days',
+        ],
+        'auth_anomalies' => [
+            'label' => 'Auth Anomalies',
+            'icon' => 'heroicon-o-finger-print',
+            'preset' => 'auth_anomalies',
+            'date_preset' => 'last_30_days',
+        ],
+        'failed_logins' => [
+            'label' => 'Failed Logins',
+            'icon' => 'heroicon-o-exclamation-triangle',
+            'preset' => 'failed_logins',
+            'date_preset' => 'last_7_days',
+        ],
+        'destructive_actions' => [
+            'label' => 'Destructive Actions',
+            'icon' => 'heroicon-o-fire',
+            'preset' => 'destructive_recent',
+            'date_preset' => 'last_7_days',
+        ],
+    ];
+
+    /**
      * @return array<string, array<string, mixed>>
      */
     public static function all(): array
     {
-        return config('filament-logger.activity_playbooks', [
-            'all_activity' => [
-                'label' => 'All Activity',
-                'icon' => 'heroicon-o-bars-3-bottom-left',
-                'preset' => 'all',
-            ],
-            'high_risk_incidents' => [
-                'label' => 'High Risk Incidents',
-                'icon' => 'heroicon-o-shield-exclamation',
-                'preset' => 'high_risk',
-                'date_preset' => 'last_30_days',
-            ],
-            'auth_anomalies' => [
-                'label' => 'Auth Anomalies',
-                'icon' => 'heroicon-o-finger-print',
-                'preset' => 'auth_anomalies',
-                'date_preset' => 'last_30_days',
-            ],
-            'failed_logins' => [
-                'label' => 'Failed Logins',
-                'icon' => 'heroicon-o-exclamation-triangle',
-                'preset' => 'failed_logins',
-                'date_preset' => 'last_7_days',
-            ],
-            'destructive_actions' => [
-                'label' => 'Destructive Actions',
-                'icon' => 'heroicon-o-fire',
-                'preset' => 'destructive_recent',
-                'date_preset' => 'last_7_days',
-            ],
-        ]);
+        return config('filament-logger.activity_playbooks', self::DEFAULT_PLAYBOOKS);
     }
 
     /**

--- a/src/Support/ActivityReviewPlaybookManager.php
+++ b/src/Support/ActivityReviewPlaybookManager.php
@@ -29,6 +29,12 @@ class ActivityReviewPlaybookManager
                 'preset' => 'auth_anomalies',
                 'date_preset' => 'last_30_days',
             ],
+            'failed_logins' => [
+                'label' => 'Failed Logins',
+                'icon' => 'heroicon-o-exclamation-triangle',
+                'preset' => 'failed_logins',
+                'date_preset' => 'last_7_days',
+            ],
             'destructive_actions' => [
                 'label' => 'Destructive Actions',
                 'icon' => 'heroicon-o-fire',

--- a/src/Widgets/ActivityOverviewWidget.php
+++ b/src/Widgets/ActivityOverviewWidget.php
@@ -22,32 +22,32 @@ class ActivityOverviewWidget extends StatsOverviewWidget
                 Stat::make('Total Activity', (string) $overview['total'])
                     ->description("Last {$this->days} days")
                     ->color('primary'),
-                'all',
+                'all_activity',
             ),
             $this->withDrillDown(
                 Stat::make('High Risk', (string) $overview['high_risk'])
                     ->description('High-risk actions detected')
                     ->color('danger'),
-                'high_risk',
+                'high_risk_incidents',
             ),
             $this->withDrillDown(
                 Stat::make('Failed Logins', (string) $overview['failed_logins'])
                     ->description('Authentication failures')
                     ->color('warning'),
-                'failed_logins',
+                'auth_anomalies',
             ),
             $this->withDrillDown(
                 Stat::make('Unique Actors', (string) $overview['unique_actors'])
                     ->description('Distinct causers recorded')
                     ->color('success'),
-                'all',
+                'all_activity',
             ),
         ];
     }
 
-    protected function withDrillDown(Stat $stat, string $preset): Stat
+    protected function withDrillDown(Stat $stat, string $playbook): Stat
     {
-        $url = ActivityReviewLink::toSavedPreset($preset);
+        $url = ActivityReviewLink::toPlaybook($playbook);
 
         if (! $url) {
             return $stat;

--- a/src/Widgets/ActivityOverviewWidget.php
+++ b/src/Widgets/ActivityOverviewWidget.php
@@ -34,7 +34,7 @@ class ActivityOverviewWidget extends StatsOverviewWidget
                 Stat::make('Failed Logins', (string) $overview['failed_logins'])
                     ->description('Authentication failures')
                     ->color('warning'),
-                'auth_anomalies',
+                'failed_logins',
             ),
             $this->withDrillDown(
                 Stat::make('Unique Actors', (string) $overview['unique_actors'])

--- a/src/Widgets/ActivityTrendChartWidget.php
+++ b/src/Widgets/ActivityTrendChartWidget.php
@@ -37,6 +37,6 @@ class ActivityTrendChartWidget extends ChartWidget
 
     public function getHeading(): string | Htmlable | null
     {
-        return $this->activityReviewHeading('Activity Trend', 'all');
+        return $this->activityReviewHeadingForPlaybook('Activity Trend', 'all_activity');
     }
 }

--- a/src/Widgets/Concerns/HasActivityReviewDrillDownHeading.php
+++ b/src/Widgets/Concerns/HasActivityReviewDrillDownHeading.php
@@ -18,4 +18,15 @@ trait HasActivityReviewDrillDownHeading
 
         return new HtmlString('<a href="'.e($url).'">'.e($heading).'</a>');
     }
+
+    protected function activityReviewHeadingForPlaybook(string $heading, string $playbook): string | Htmlable | null
+    {
+        $url = ActivityReviewLink::toPlaybook($playbook);
+
+        if (! $url) {
+            return $heading;
+        }
+
+        return new HtmlString('<a href="'.e($url).'">'.e($heading).'</a>');
+    }
 }

--- a/src/Widgets/Concerns/HasActivityReviewDrillDownHeading.php
+++ b/src/Widgets/Concerns/HasActivityReviewDrillDownHeading.php
@@ -10,19 +10,16 @@ trait HasActivityReviewDrillDownHeading
 {
     protected function activityReviewHeading(string $heading, string $preset): string | Htmlable | null
     {
-        $url = ActivityReviewLink::toSavedPreset($preset);
-
-        if (! $url) {
-            return $heading;
-        }
-
-        return new HtmlString('<a href="'.e($url).'">'.e($heading).'</a>');
+        return $this->activityReviewHeadingFromUrl($heading, ActivityReviewLink::toSavedPreset($preset));
     }
 
     protected function activityReviewHeadingForPlaybook(string $heading, string $playbook): string | Htmlable | null
     {
-        $url = ActivityReviewLink::toPlaybook($playbook);
+        return $this->activityReviewHeadingFromUrl($heading, ActivityReviewLink::toPlaybook($playbook));
+    }
 
+    protected function activityReviewHeadingFromUrl(string $heading, ?string $url): string | Htmlable | null
+    {
         if (! $url) {
             return $heading;
         }

--- a/src/Widgets/HighRiskActionsChartWidget.php
+++ b/src/Widgets/HighRiskActionsChartWidget.php
@@ -42,6 +42,6 @@ class HighRiskActionsChartWidget extends ChartWidget
 
     public function getHeading(): string | Htmlable | null
     {
-        return $this->activityReviewHeading('High-Risk Actions', 'high_risk');
+        return $this->activityReviewHeadingForPlaybook('High-Risk Actions', 'high_risk_incidents');
     }
 }

--- a/src/Widgets/TopEventsChartWidget.php
+++ b/src/Widgets/TopEventsChartWidget.php
@@ -42,6 +42,6 @@ class TopEventsChartWidget extends ChartWidget
 
     public function getHeading(): string | Htmlable | null
     {
-        return $this->activityReviewHeading('Top Events', 'all');
+        return $this->activityReviewHeadingForPlaybook('Top Events', 'all_activity');
     }
 }

--- a/src/Widgets/TopUsersChartWidget.php
+++ b/src/Widgets/TopUsersChartWidget.php
@@ -42,6 +42,6 @@ class TopUsersChartWidget extends ChartWidget
 
     public function getHeading(): string | Htmlable | null
     {
-        return $this->activityReviewHeading('Top Users', 'all');
+        return $this->activityReviewHeadingForPlaybook('Top Users', 'all_activity');
     }
 }

--- a/tests/Unit/ActivityReviewLinkTest.php
+++ b/tests/Unit/ActivityReviewLinkTest.php
@@ -4,11 +4,12 @@ use MrAdder\FilamentLogger\Support\ActivityReviewLink;
 use MrAdder\FilamentLogger\Widgets\HighRiskActionsChartWidget;
 use MrAdder\FilamentLogger\Widgets\TopEventsChartWidget;
 
-const ACTIVITY_REVIEW_ACTIVE_TAB_HIGH_RISK = 'activeTab=high_risk';
-const ACTIVITY_REVIEW_TABLE_FILTERS = 'tableFilters';
-
 class ActivityReviewLinkFakeResource
 {
+    public const ACTIVE_TAB_HIGH_RISK = 'activeTab=high_risk';
+
+    public const TABLE_FILTERS = 'tableFilters';
+
     /**
      * @param  array<int, mixed>  $arguments
      */
@@ -28,7 +29,7 @@ it('builds activity resource links for saved presets', function () {
 
     expect($url)
         ->toBeString()
-        ->toContain(ACTIVITY_REVIEW_ACTIVE_TAB_HIGH_RISK);
+        ->toContain(ActivityReviewLinkFakeResource::ACTIVE_TAB_HIGH_RISK);
 });
 
 it('builds activity resource links for playbooks', function () {
@@ -38,8 +39,8 @@ it('builds activity resource links for playbooks', function () {
 
     expect($url)
         ->toBeString()
-        ->toContain(ACTIVITY_REVIEW_ACTIVE_TAB_HIGH_RISK)
-        ->toContain(ACTIVITY_REVIEW_TABLE_FILTERS);
+        ->toContain(ActivityReviewLinkFakeResource::ACTIVE_TAB_HIGH_RISK)
+        ->toContain(ActivityReviewLinkFakeResource::TABLE_FILTERS);
 });
 
 it('returns null when no activity resource is configured', function () {
@@ -55,7 +56,7 @@ it('renders chart headings with drill-down links', function () {
     $topEventsHeading = (string) (new TopEventsChartWidget())->getHeading();
 
     expect($highRiskHeading)
-        ->toContain(ACTIVITY_REVIEW_ACTIVE_TAB_HIGH_RISK)
+        ->toContain(ActivityReviewLinkFakeResource::ACTIVE_TAB_HIGH_RISK)
         ->and($topEventsHeading)
         ->toContain('activeTab=all');
 });

--- a/tests/Unit/ActivityReviewLinkTest.php
+++ b/tests/Unit/ActivityReviewLinkTest.php
@@ -4,6 +4,9 @@ use MrAdder\FilamentLogger\Support\ActivityReviewLink;
 use MrAdder\FilamentLogger\Widgets\HighRiskActionsChartWidget;
 use MrAdder\FilamentLogger\Widgets\TopEventsChartWidget;
 
+const ACTIVITY_REVIEW_ACTIVE_TAB_HIGH_RISK = 'activeTab=high_risk';
+const ACTIVITY_REVIEW_TABLE_FILTERS = 'tableFilters';
+
 class ActivityReviewLinkFakeResource
 {
     /**
@@ -12,9 +15,9 @@ class ActivityReviewLinkFakeResource
     public static function getUrl(...$arguments): string
     {
         $parameters = is_array($arguments[1] ?? null) ? $arguments[1] : [];
-        $activeTab = $parameters['activeTab'] ?? 'all';
+        $query = http_build_query($parameters);
 
-        return 'https://example.test/activity?activeTab='.$activeTab;
+        return 'https://example.test/activity'.($query !== '' ? '?'.$query : '');
     }
 }
 
@@ -25,7 +28,18 @@ it('builds activity resource links for saved presets', function () {
 
     expect($url)
         ->toBeString()
-        ->toContain('activeTab=high_risk');
+        ->toContain(ACTIVITY_REVIEW_ACTIVE_TAB_HIGH_RISK);
+});
+
+it('builds activity resource links for playbooks', function () {
+    config()->set('filament-logger.activity_resource', ActivityReviewLinkFakeResource::class);
+
+    $url = ActivityReviewLink::toPlaybook('high_risk_incidents');
+
+    expect($url)
+        ->toBeString()
+        ->toContain(ACTIVITY_REVIEW_ACTIVE_TAB_HIGH_RISK)
+        ->toContain(ACTIVITY_REVIEW_TABLE_FILTERS);
 });
 
 it('returns null when no activity resource is configured', function () {
@@ -41,7 +55,7 @@ it('renders chart headings with drill-down links', function () {
     $topEventsHeading = (string) (new TopEventsChartWidget())->getHeading();
 
     expect($highRiskHeading)
-        ->toContain('activeTab=high_risk')
+        ->toContain(ACTIVITY_REVIEW_ACTIVE_TAB_HIGH_RISK)
         ->and($topEventsHeading)
         ->toContain('activeTab=all');
 });

--- a/tests/Unit/ActivityReviewPlaybookManagerTest.php
+++ b/tests/Unit/ActivityReviewPlaybookManagerTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use MrAdder\FilamentLogger\Support\ActivityReviewPlaybookManager;
+
+it('provides built-in investigation playbooks', function () {
+    $playbooks = ActivityReviewPlaybookManager::all();
+
+    expect($playbooks)->toHaveKeys([
+        'all_activity',
+        'high_risk_incidents',
+        'auth_anomalies',
+        'destructive_actions',
+    ]);
+});
+
+it('resolves playbook url parameters with optional date preset', function () {
+    $highRisk = ActivityReviewPlaybookManager::toUrlParameters('high_risk_incidents');
+    $all = ActivityReviewPlaybookManager::toUrlParameters('all_activity');
+
+    expect($highRisk['activeTab'])->toBe('high_risk')
+        ->and($highRisk['tableFilters']['created_at']['preset'])->toBe('last_30_days')
+        ->and($all['activeTab'])->toBe('all')
+        ->and($all)->not->toHaveKey('tableFilters');
+});
+
+it('returns empty parameters for unknown playbooks', function () {
+    expect(ActivityReviewPlaybookManager::toUrlParameters('unknown-playbook'))->toBe([]);
+});

--- a/tests/Unit/ActivityReviewPlaybookManagerTest.php
+++ b/tests/Unit/ActivityReviewPlaybookManagerTest.php
@@ -9,6 +9,7 @@ it('provides built-in investigation playbooks', function () {
         'all_activity',
         'high_risk_incidents',
         'auth_anomalies',
+        'failed_logins',
         'destructive_actions',
     ]);
 });


### PR DESCRIPTION
## Summary

- Adds built-in investigation playbooks that bundle saved review presets with optional date presets.
- Improves review speed by enabling one-click navigation into coherent filtered activity views.
- Extends the existing tabs/widgets flow without breaking current saved-preset behavior.

## Changes

- Added playbook management and parameter resolution in `ActivityReviewPlaybookManager`.
- Added playbook URL support in `ActivityReviewLink` while keeping preset URL support.
- Added a `Playbooks` action group on the Activity list header for direct workflow entry points.
- Updated dashboard drill-down links to use playbooks for consistent review paths.
- Added default `activity_playbooks` configuration with:
  - `all_activity`
  - `high_risk_incidents`
  - `auth_anomalies`
  - `destructive_actions`
- Updated activity review docs with playbook configuration and behavior.
- Added/updated unit tests for playbook resolution and link generation behavior.

## Testing

- Ran focused unit tests:
  - `tests/Unit/ActivityReviewPlaybookManagerTest.php`
  - `tests/Unit/ActivityReviewLinkTest.php`
- Ran full suite via `composer test` (all passing).

## Screenshots

- Not included in this PR.

## Checklist

- [x] Linked the related issue, or explained why there is no linked issue
- [x] Updated documentation or configuration where needed
- [x] Added or updated tests where needed
- [x] Verified the relevant checks locally
- [x] Noted any breaking changes or follow-up work below

## Breaking Changes / Follow-Up

- None.