### PR TITLE
chore: update GitHub repository link in install command

### DIFF
--- a/src/FilamentLoggerServiceProvider.php
+++ b/src/FilamentLoggerServiceProvider.php
@@ -53,7 +53,7 @@ class FilamentLoggerServiceProvider extends PackageServiceProvider
             ->hasInstallCommand(function (InstallCommand $installCommand) {
                 $installCommand
                     ->publishConfigFile()
-                    ->askToStarRepoOnGitHub('z3d0x/filament-logger')
+                    ->askToStarRepoOnGitHub('MrAdder/filament-logger')
                     ->startWith(function (InstallCommand $installCommand) {
                         $installCommand->call('vendor:publish', [
                             '--provider' => "Spatie\Activitylog\ActivitylogServiceProvider",


### PR DESCRIPTION
## Summary

Updates the GitHub repository link used in the package install command to point to the correct repository. Previously, the `askToStarRepoOnGitHub` call referenced the old upstream repo (`z3d0x/filament-logger`), which no longer reflects the active maintainer. This change ensures users are directed to the correct repository when prompted to star after installation.

## Changes

- Updated `askToStarRepoOnGitHub` in `FilamentLoggerServiceProvider` from `z3d0x/filament-logger` to `MrAdder/filament-logger`

## Testing

- No logic changes; verified the install command prompt points to the correct repo by inspecting the updated value in `FilamentLoggerServiceProvider.php`

## Screenshots

N/A — no UI changes.

## Checklist

- [x] Linked the related issue, or explained why there is no linked issue
- [x] Updated documentation or configuration where needed
- [x] Added or updated tests where needed
- [x] Verified the relevant checks locally
- [x] Noted any breaking changes or follow-up work below

## Breaking Changes / Follow-Up

- None