### PR TITLE
fix: add guard allow-list for access logger in multi-guard apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,34 @@ public function panel(Panel $panel): Panel
 - [Custom Events and Alerts](https://mradder.github.io/filament-logger/custom-events)
 - [Roadmap](https://mradder.github.io/filament-logger/roadmap)
 
+## Filtering By Auth Guard
+
+In multi-guard applications, you can scope access-event logging to specific guards.
+
+Set `access.guards` to an allow-list:
+
+```php
+'access' => [
+    // ...
+    'guards' => ['web'],
+],
+```
+
+Behavior:
+
+- `null` (default): log access events from all guards (backward compatible behavior)
+- `['web']` (or any list): for events that include a `guard` property (`Login`, `Logout`, `Failed`), only the listed guards are logged
+- events without a `guard` property (`Lockout`, `PasswordReset`, and optional Fortify recovery-code events) continue to be logged
+
+Example for a Filament panel + storefront app:
+
+```php
+'access' => [
+    // Log only panel auth events from the web guard.
+    'guards' => ['web'],
+],
+```
+
 ## Screenshots
 
 <img alt="Filament Logger dashboard widgets" src="https://raw.githubusercontent.com/MrAdder/filament-logger/main/art/activity-review-dashboard-widgets.png">

--- a/config/filament-logger.php
+++ b/config/filament-logger.php
@@ -213,6 +213,7 @@ return [
         'logger' => \MrAdder\FilamentLogger\Loggers\AccessLogger::class,
         'color' => 'danger',
         'log_name' => 'Access',
+        'guards' => null,
         'store_ip' => true,
         'anonymize_ip' => true,
         'redact_ip_for_unauthorized_viewers' => false,

--- a/src/Loggers/AccessLogger.php
+++ b/src/Loggers/AccessLogger.php
@@ -18,6 +18,10 @@ class AccessLogger
 {
     public function handle(mixed $event): void
     {
+        if (! $this->shouldLogEvent($event)) {
+            return;
+        }
+
         [$eventName, $description, $properties, $causer] = match (true) {
             $event instanceof Login => [
                 'Login',
@@ -123,5 +127,20 @@ class AccessLogger
             && class_basename($event) === 'RecoveryCodeReplaced'
             && property_exists($event, 'user')
             && ($event->user instanceof Authenticatable);
+    }
+
+    protected function shouldLogEvent(mixed $event): bool
+    {
+        $allowedGuards = config('filament-logger.access.guards');
+
+        if ($allowedGuards === null) {
+            return true;
+        }
+
+        if (! is_object($event) || ! property_exists($event, 'guard')) {
+            return true;
+        }
+
+        return in_array($event->guard, (array) $allowedGuards, true);
     }
 }

--- a/tests/Feature/AccessLoggerTest.php
+++ b/tests/Feature/AccessLoggerTest.php
@@ -59,3 +59,31 @@ it('logs the expanded set of auth events with sanitized metadata', function () {
 
     expect(data_get($recovery->properties->toArray(), 'used_recovery_code'))->toBeTrue();
 });
+
+it('filters guard-based access events when an allow-list is configured', function () {
+    config()->set('filament-logger.access.guards', ['web']);
+
+    $user = TestUser::query()->create([
+        'name' => 'Taylor',
+        'email' => 'taylor@example.com',
+    ]);
+
+    $request = Request::create('/login', 'POST', [
+        'email' => 'taylor@example.com',
+        'password' => 'super-secret',
+    ]);
+    $request->server->set('REMOTE_ADDR', '192.168.1.44');
+    $request->headers->set('User-Agent', 'Mozilla/5.0 (Test Browser)');
+    $this->app->instance('request', $request);
+
+    $logger = new AccessLogger();
+
+    $logger->handle(new Login('customer', $user, false));
+
+    expect(Activity::query()->count())->toBe(0);
+
+    $logger->handle(new Login('web', $user, false));
+
+    expect(Activity::query()->count())->toBe(1)
+        ->and(Activity::query()->firstOrFail()->event)->toBe('Login');
+});


### PR DESCRIPTION
## Summary

- This PR fixes a multi-guard auth logging bug where access events from non-panel guards were still processed by the access logger.
- It adds guard-based filtering so panel-focused audit logs are not polluted by storefront/customer guard events.
- User-facing impact:
- Prevents crashes caused by non-panel user models when excluded guards trigger auth events.
- Keeps activity logs focused on intended panel/staff access events.
- Preserves backward compatibility by default.

## Changes

- Added a new access guard allow-list configuration key:
- `access.guards` with default `null` (log all guards, current behavior).
- Updated access event handling to short-circuit early when an event has a `guard` that is not in the allow-list.
- Preserved behavior for events without a `guard` property (they continue to be logged).
- Added documentation for multi-guard filtering with example configuration.
- Added a feature regression test covering:
- non-allow-listed guard login is not logged
- allow-listed guard login is logged

- Reviewer attention points:
- Verify the default `null` behavior is fully non-breaking.
- Confirm event behavior without `guard` property matches the documented choice.
- Confirm filtering happens before any side effects for excluded guards.

## Testing

- Added/updated automated feature coverage for guard filtering behavior.
- Suggested command to run locally:
- `composer test`
- Suggested targeted command:
- `vendor/bin/pest tests/Feature/AccessLoggerTest.php`

- Manual verification steps:
1. Configure `access.guards` to only include `web`.
2. Trigger login on a different guard such as `customer`.
3. Confirm no access activity row is created.
4. Trigger login on `web` and confirm an access activity row is created.

## Screenshots

- None (no UI changes).

## Checklist

- [x] Linked the related issue, or explained why there is no linked issue
- [x] Updated documentation or configuration where needed
- [x] Added or updated tests where needed
- [ ] Verified the relevant checks locally
- [x] Noted any breaking changes or follow-up work below

## Breaking Changes / Follow-Up

- None

Related issue: #53