### PR TITLE
Document access.guards config for multi-guard apps

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,22 @@ Auth event logging is configurable per event:
 
 The 2FA recovery event is only registered when the Fortify event class is available.
 
+In multi-guard applications, you can scope guard-based access logging with `access.guards`:
+
+```php
+'access' => [
+    'guards' => ['web'],
+],
+```
+
+Guard filter behavior:
+
+- `null` (default): log access events for all guards
+- `['web']` (or any list): for events with a `guard` property (`Login`, `Logout`, `Failed`), only listed guards are logged
+- events without a `guard` property (`Lockout`, `PasswordReset`, and optional Fortify recovery-code events) continue to be logged
+
+This keeps panel access logs focused in apps that also have storefront or customer guards.
+
 You can also redact stored IP addresses at view/export time for users who do not pass the sensitive-data policy ability:
 
 ```php


### PR DESCRIPTION
This pull request updates the documentation to clarify how access event logging can be scoped by authentication guard in multi-guard applications. The new section explains how to configure which guards' events are logged, and how the filter behaves for different event types.

**Documentation improvements:**

* Added an explanation and example for configuring `access.guards` in multi-guard applications, including details on default behavior and how events with and without a `guard` property are handled.Add documentation for an access.guards configuration option that scopes guard-based access logging in multi-guard applications. Shows example usage (e.g. 'access' => ['guards' => ['web']]) and explains filter behavior: null logs all guards; a list restricts guard-bearing events (Login, Logout, Failed) to listed guards; events without a guard property (Lockout, PasswordReset, optional Fortify recovery-code events) continue to be logged. Notes this keeps panel access logs focused when apps also have storefront/customer guards.

## Summary

- Describe the purpose of this PR.
- Include any important context or user-facing impact.

## Changes

- List the main code or documentation changes.
- Call out anything reviewers should pay special attention to.

## Testing

- Describe what you tested.
- Include commands or manual verification steps where useful.

## Screenshots

- Add screenshots or recordings for UI changes, if applicable.

## Checklist

- [ ] Linked the related issue, or explained why there is no linked issue
- [ ] Updated documentation or configuration where needed
- [ ] Added or updated tests where needed
- [ ] Verified the relevant checks locally
- [ ] Noted any breaking changes or follow-up work below

## Breaking Changes / Follow-Up

- None
