### PR TITLE
Add broad multi-field activity search (description, subject, causer, tags)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,4 +169,17 @@ You can define your own log names and colors:
     'default_log_name' => 'Custom',
     'color' => 'primary',
 ],
+
+## Search
+
+The activity table includes a broad search box that scans multiple high-value fields to help investigations when you only have partial context. The search looks across:
+
+- `description`
+- `subject_type`
+- `causer` name
+- `properties` JSON (useful for tags or payload values)
+
+Search integrates with existing filters and sorting — it's implemented as a table filter, so applying a search term will narrow results alongside any selected filters or sort order. The search performs SQL `LIKE` matching against these fields (for JSON payloads it performs a `LIKE` against the JSON column), so behavior is predictable across supported database engines.
+
+If you need more advanced full-text search (language-aware stemming, ranking, or very large datasets), consider integrating a dedicated search engine (e.g., Meilisearch, Algolia, or database full-text indexes) and adapting the filter's query logic.
 ```

--- a/resources/lang/en/filament-logger.php
+++ b/resources/lang/en/filament-logger.php
@@ -20,6 +20,8 @@ return [
     'resource.label.type' => 'Type',
     'resource.label.event' => 'Event',
     'resource.label.logged_at' => 'Logged At',
+    'resource.label.search' => 'Search',
+    'resource.placeholder.search' => 'Search description, subject, user or tags',
     'resource.label.properties' => 'Properties',
     'resource.label.old' => 'Old',
     'resource.label.new' => 'New',

--- a/src/Resources/ActivityResourceV3.php
+++ b/src/Resources/ActivityResourceV3.php
@@ -22,7 +22,7 @@ class ActivityResourceV3 extends BaseActivityResource
 
     protected static function configureFilterFields(Filter $filter, array $fields): Filter
     {
-        return $filter->form($fields);
+        return $filter->schema($fields);
     }
 
     protected static function makeInfolistSection(string $label): InfolistSection

--- a/src/Resources/BaseActivityResource.php
+++ b/src/Resources/BaseActivityResource.php
@@ -86,7 +86,7 @@ abstract class BaseActivityResource extends AbstractActivityResource
         return [
             // Search across high-value fields: description, causer name, subject type and properties
             Filter::make('search')
-                ->form([
+                ->schema([
                     TextInput::make('query')
                         ->label(static::resourceLabel('search'))
                         ->placeholder(__('filament-logger::filament-logger.resource.placeholder.search')),

--- a/src/Resources/BaseActivityResource.php
+++ b/src/Resources/BaseActivityResource.php
@@ -84,6 +84,29 @@ abstract class BaseActivityResource extends AbstractActivityResource
     protected static function getTableFilters(): array
     {
         return [
+            // Search across high-value fields: description, causer name, subject type and properties
+            Filter::make('search')
+                ->form([
+                    TextInput::make('query')
+                        ->label(static::resourceLabel('search'))
+                        ->placeholder(__('filament-logger::filament-logger.resource.placeholder.search')),
+                ])
+                ->query(function (Builder $query, array $data): Builder {
+                    $search = $data['query'] ?? null;
+
+                    if (! filled($search)) {
+                        return $query;
+                    }
+
+                    return $query->where(function (Builder $q) use ($search) {
+                        $q->where('description', 'like', "%{$search}%")
+                            ->orWhere('subject_type', 'like', "%{$search}%")
+                            ->orWhere('properties', 'like', "%{$search}%")
+                            ->orWhereHas('causer', function (Builder $q2) use ($search) {
+                                $q2->where('name', 'like', "%{$search}%");
+                            });
+                    });
+                }),
             SelectFilter::make('log_name')
                 ->label(static::resourceLabel('type'))
                 ->options(ActivityResourceTableOptions::logNames()),

--- a/tests/Feature/ActivityResourceSearchTest.php
+++ b/tests/Feature/ActivityResourceSearchTest.php
@@ -34,5 +34,6 @@ it('finds activities by broad search terms', function () {
             });
     })->get();
 
-    expect($results->pluck('id'))->toContain($first->id)->and->not->toContain($second->id);
+    expect($results->pluck('id'))->toContain($first->id);
+    expect($results->pluck('id'))->not->toContain($second->id);
 });

--- a/tests/Feature/ActivityResourceSearchTest.php
+++ b/tests/Feature/ActivityResourceSearchTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Spatie\Activitylog\Models\Activity as ActivityModel;
+
+it('finds activities by broad search terms', function () {
+    // create two records with distinct searchable content
+    $first = ActivityModel::create([
+        'log_name' => 'default',
+        'description' => 'Updated email address for user',
+        'subject_type' => 'App\\Models\\User',
+        'subject_id' => 1,
+        'event' => 'updated',
+        'properties' => ['tags' => ['email', 'user']],
+    ]);
+
+    $second = ActivityModel::create([
+        'log_name' => 'default',
+        'description' => 'Deleted order #42',
+        'subject_type' => 'App\\Models\\Order',
+        'subject_id' => 42,
+        'event' => 'deleted',
+        'properties' => ['tags' => ['order', 'delete']],
+    ]);
+
+    // replicate the search logic used by the resource filter
+    $term = 'email';
+
+    $results = ActivityModel::where(function ($q) use ($term) {
+        $q->where('description', 'like', "%{$term}%")
+            ->orWhere('subject_type', 'like', "%{$term}%")
+            ->orWhere('properties', 'like', "%{$term}%")
+            ->orWhereHas('causer', function ($q2) use ($term) {
+                $q2->where('name', 'like', "%{$term}%");
+            });
+    })->get();
+
+    expect($results->pluck('id'))->toContain($first->id)->and->not->toContain($second->id);
+});


### PR DESCRIPTION
Summary
- Adds a broad search box to the activity table that searches high-value fields to help investigative workflows when users only have partial context.

What this changes
- Implements a table `Filter::make('search')` that performs SQL `LIKE` matching across:
  - `description`
  - `subject_type`
  - `properties` JSON (covers `tags` and payload values)
  - related `causer.name`
  (Implemented in `src/Resources/BaseActivityResource.php`)
- Adds a feature test that verifies the search returns relevant records (see `tests/Feature/ActivityResourceSearchTest.php`).
- Documents the feature and trade-offs in `docs/configuration.md`.

Acceptance criteria
- Users can search across multiple fields: implemented (description, subject, causer, properties/tags).
- Search integrates with existing filters and sorting: implemented as a table filter; search narrows results alongside other filters/sorts.
- Search behavior is documented and predictable: docs explain SQL `LIKE` semantics and limitations.

Testing
- Unit/feature test included: `tests/Feature/ActivityResourceSearchTest.php` replicates the filter logic and asserts expected matches.
- Manual verification: apply a search term in the activity table UI and confirm results narrow as expected with other filters applied.

Notes & caveats
- The implementation uses SQL `LIKE` (including a `LIKE` against the JSON `properties` column). This is widely compatible and predictable but not optimized for ranking, stemming, or very large datasets.
- For advanced requirements (fuzzy matching, ranking, language-aware search, scale), recommend integrating a dedicated search backend (Meilisearch/Algolia) or DB full-text indexes and adapting the filter logic accordingly.

Changelog / roadmap
- The change aligns with the v1.3.0 "Search and productivity" item in the roadmap.

Closes
- Fixes #17