### PR TITLE
Improve pruning dry-run summaries and reporting

### DIFF
--- a/src/Commands/PruneActivitiesCommand.php
+++ b/src/Commands/PruneActivitiesCommand.php
@@ -49,11 +49,14 @@ class PruneActivitiesCommand extends Command
         }
 
         $count = (clone $query)->count();
+        $breakdown = $this->buildPruningBreakdown(clone $query);
+        $this->components->info($this->formatPruningScopeSummary($days, $logNames, $excludedLogNames));
+        $this->components->info($this->formatPruningBreakdownSummary($breakdown));
 
         if ($count === 0) {
             $this->components->info('No activity records matched the pruning rules.');
         } elseif ($this->option('dry-run')) {
-            $this->components->info("{$count} activity record(s) would be pruned.");
+            $this->components->info("Dry run: {$count} activity record(s) would be pruned.");
         } else {
             $deleted = $query->delete();
 
@@ -75,5 +78,49 @@ class PruneActivitiesCommand extends Command
                 $logNames,
             ),
         )));
+    }
+
+    /**
+     * @param  array<int, string>  $logNames
+     * @param  array<int, string>  $excludedLogNames
+     */
+    protected function formatPruningScopeSummary(int $days, array $logNames, array $excludedLogNames): string
+    {
+        $matchingLogNames = $logNames !== [] ? implode(', ', $logNames) : 'all log names';
+        $excludedLabel = $excludedLogNames !== [] ? implode(', ', $excludedLogNames) : 'none';
+
+        return "Pruning scope: older than {$days} day(s); matching log names: {$matchingLogNames}; excluded log names: {$excludedLabel}.";
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    protected function buildPruningBreakdown($query): array
+    {
+        return $query
+            ->selectRaw('log_name, COUNT(*) as aggregate')
+            ->groupBy('log_name')
+            ->orderBy('log_name')
+            ->pluck('aggregate', 'log_name')
+            ->map(static fn ($value): int => (int) $value)
+            ->all();
+    }
+
+    /**
+     * @param  array<string, int>  $breakdown
+     */
+    protected function formatPruningBreakdownSummary(array $breakdown): string
+    {
+        if ($breakdown === []) {
+            return 'Matching records by log name: none.';
+        }
+
+        $parts = [];
+
+        foreach ($breakdown as $logName => $count) {
+            $parts[] = "{$logName} ({$count})";
+        }
+
+        return 'Matching records by log name: '.implode(', ', $parts).'.';
     }
 }

--- a/tests/Feature/PruneActivitiesCommandTest.php
+++ b/tests/Feature/PruneActivitiesCommandTest.php
@@ -31,6 +31,9 @@ it('prunes only matching old activity records', function () {
     ]);
 
     $this->artisan('filament-logger:prune')
+        ->expectsOutputToContain('Pruning scope: older than 30 day(s); matching log names: Access; excluded log names: none.')
+        ->expectsOutputToContain('Matching records by log name: Access (1).')
+        ->expectsOutputToContain('Pruned 1 activity record(s).')
         ->assertSuccessful();
 
     expect(Activity::query()->orderBy('id')->pluck('description')->all())
@@ -52,7 +55,64 @@ it('supports dry-run pruning', function () {
     ]);
 
     $this->artisan('filament-logger:prune', ['--dry-run' => true])
+        ->expectsOutputToContain('Pruning scope: older than 30 day(s); matching log names: all log names; excluded log names: none.')
+        ->expectsOutputToContain('Matching records by log name: Access (1).')
+        ->expectsOutputToContain('Dry run: 1 activity record(s) would be pruned.')
         ->assertSuccessful();
 
     expect(Activity::query()->count())->toBe(1);
+});
+
+it('reports when nothing matches pruning rules', function () {
+    config()->set('filament-logger.pruning.days', 30);
+    config()->set('filament-logger.pruning.only', ['Access']);
+    config()->set('filament-logger.pruning.except', ['Notification']);
+
+    Activity::query()->create([
+        'log_name' => 'Notification',
+        'description' => 'Old notification record',
+        'event' => 'Notification Sent',
+        'created_at' => now()->subDays(40),
+        'updated_at' => now()->subDays(40),
+    ]);
+
+    $this->artisan('filament-logger:prune')
+        ->expectsOutputToContain('Pruning scope: older than 30 day(s); matching log names: Access; excluded log names: Notification.')
+        ->expectsOutputToContain('Matching records by log name: none.')
+        ->expectsOutputToContain('No activity records matched the pruning rules.')
+        ->assertSuccessful();
+
+    expect(Activity::query()->count())->toBe(1);
+});
+
+it('reports real prune summaries with excluded log names', function () {
+    config()->set('filament-logger.pruning.days', 30);
+    config()->set('filament-logger.pruning.except', ['Notification']);
+
+    Activity::query()->create([
+        'log_name' => 'Access',
+        'description' => 'Old access record',
+        'event' => 'Login',
+        'created_at' => now()->subDays(40),
+        'updated_at' => now()->subDays(40),
+    ]);
+
+    Activity::query()->create([
+        'log_name' => 'Notification',
+        'description' => 'Old notification record',
+        'event' => 'Notification Sent',
+        'created_at' => now()->subDays(40),
+        'updated_at' => now()->subDays(40),
+    ]);
+
+    $this->artisan('filament-logger:prune')
+        ->expectsOutputToContain('Pruning scope: older than 30 day(s); matching log names: all log names; excluded log names: Notification.')
+        ->expectsOutputToContain('Matching records by log name: Access (1).')
+        ->expectsOutputToContain('Pruned 1 activity record(s).')
+        ->assertSuccessful();
+
+    expect(Activity::query()->orderBy('id')->pluck('description')->all())
+        ->toBe([
+            'Old notification record',
+        ]);
 });

--- a/tests/Feature/PruneActivitiesCommandTest.php
+++ b/tests/Feature/PruneActivitiesCommandTest.php
@@ -2,38 +2,39 @@
 
 use Spatie\Activitylog\Models\Activity;
 
+function createPruneActivity(string $logName, string $description, string $event, int $daysAgo): void
+{
+    Activity::query()->create([
+        'log_name' => $logName,
+        'description' => $description,
+        'event' => $event,
+        'created_at' => now()->subDays($daysAgo),
+        'updated_at' => now()->subDays($daysAgo),
+    ]);
+}
+
+function expectPruneSummary($command, string $scopeSummary, string $breakdownSummary, string $resultSummary)
+{
+    return $command
+        ->expectsOutputToContain($scopeSummary)
+        ->expectsOutputToContain($breakdownSummary)
+        ->expectsOutputToContain($resultSummary);
+}
+
 it('prunes only matching old activity records', function () {
     config()->set('filament-logger.pruning.days', 30);
     config()->set('filament-logger.pruning.only', ['Access']);
 
-    Activity::query()->create([
-        'log_name' => 'Access',
-        'description' => 'Old access record',
-        'event' => 'Login',
-        'created_at' => now()->subDays(40),
-        'updated_at' => now()->subDays(40),
-    ]);
+    createPruneActivity('Access', 'Old access record', 'Login', 40);
+    createPruneActivity('Notification', 'Old notification record', 'Notification Sent', 40);
+    createPruneActivity('Access', 'Recent access record', 'Login', 5);
 
-    Activity::query()->create([
-        'log_name' => 'Notification',
-        'description' => 'Old notification record',
-        'event' => 'Notification Sent',
-        'created_at' => now()->subDays(40),
-        'updated_at' => now()->subDays(40),
-    ]);
-
-    Activity::query()->create([
-        'log_name' => 'Access',
-        'description' => 'Recent access record',
-        'event' => 'Login',
-        'created_at' => now()->subDays(5),
-        'updated_at' => now()->subDays(5),
-    ]);
-
-    $this->artisan('filament-logger:prune')
-        ->expectsOutputToContain('Pruning scope: older than 30 day(s); matching log names: Access; excluded log names: none.')
-        ->expectsOutputToContain('Matching records by log name: Access (1).')
-        ->expectsOutputToContain('Pruned 1 activity record(s).')
+    expectPruneSummary(
+        $this->artisan('filament-logger:prune'),
+        'Pruning scope: older than 30 day(s); matching log names: Access; excluded log names: none.',
+        'Matching records by log name: Access (1).',
+        'Pruned 1 activity record(s).',
+    )
         ->assertSuccessful();
 
     expect(Activity::query()->orderBy('id')->pluck('description')->all())
@@ -46,18 +47,14 @@ it('prunes only matching old activity records', function () {
 it('supports dry-run pruning', function () {
     config()->set('filament-logger.pruning.days', 30);
 
-    Activity::query()->create([
-        'log_name' => 'Access',
-        'description' => 'Old access record',
-        'event' => 'Login',
-        'created_at' => now()->subDays(40),
-        'updated_at' => now()->subDays(40),
-    ]);
+    createPruneActivity('Access', 'Old access record', 'Login', 40);
 
-    $this->artisan('filament-logger:prune', ['--dry-run' => true])
-        ->expectsOutputToContain('Pruning scope: older than 30 day(s); matching log names: all log names; excluded log names: none.')
-        ->expectsOutputToContain('Matching records by log name: Access (1).')
-        ->expectsOutputToContain('Dry run: 1 activity record(s) would be pruned.')
+    expectPruneSummary(
+        $this->artisan('filament-logger:prune', ['--dry-run' => true]),
+        'Pruning scope: older than 30 day(s); matching log names: all log names; excluded log names: none.',
+        'Matching records by log name: Access (1).',
+        'Dry run: 1 activity record(s) would be pruned.',
+    )
         ->assertSuccessful();
 
     expect(Activity::query()->count())->toBe(1);
@@ -68,18 +65,14 @@ it('reports when nothing matches pruning rules', function () {
     config()->set('filament-logger.pruning.only', ['Access']);
     config()->set('filament-logger.pruning.except', ['Notification']);
 
-    Activity::query()->create([
-        'log_name' => 'Notification',
-        'description' => 'Old notification record',
-        'event' => 'Notification Sent',
-        'created_at' => now()->subDays(40),
-        'updated_at' => now()->subDays(40),
-    ]);
+    createPruneActivity('Notification', 'Old notification record', 'Notification Sent', 40);
 
-    $this->artisan('filament-logger:prune')
-        ->expectsOutputToContain('Pruning scope: older than 30 day(s); matching log names: Access; excluded log names: Notification.')
-        ->expectsOutputToContain('Matching records by log name: none.')
-        ->expectsOutputToContain('No activity records matched the pruning rules.')
+    expectPruneSummary(
+        $this->artisan('filament-logger:prune'),
+        'Pruning scope: older than 30 day(s); matching log names: Access; excluded log names: Notification.',
+        'Matching records by log name: none.',
+        'No activity records matched the pruning rules.',
+    )
         ->assertSuccessful();
 
     expect(Activity::query()->count())->toBe(1);
@@ -89,26 +82,15 @@ it('reports real prune summaries with excluded log names', function () {
     config()->set('filament-logger.pruning.days', 30);
     config()->set('filament-logger.pruning.except', ['Notification']);
 
-    Activity::query()->create([
-        'log_name' => 'Access',
-        'description' => 'Old access record',
-        'event' => 'Login',
-        'created_at' => now()->subDays(40),
-        'updated_at' => now()->subDays(40),
-    ]);
+    createPruneActivity('Access', 'Old access record', 'Login', 40);
+    createPruneActivity('Notification', 'Old notification record', 'Notification Sent', 40);
 
-    Activity::query()->create([
-        'log_name' => 'Notification',
-        'description' => 'Old notification record',
-        'event' => 'Notification Sent',
-        'created_at' => now()->subDays(40),
-        'updated_at' => now()->subDays(40),
-    ]);
-
-    $this->artisan('filament-logger:prune')
-        ->expectsOutputToContain('Pruning scope: older than 30 day(s); matching log names: all log names; excluded log names: Notification.')
-        ->expectsOutputToContain('Matching records by log name: Access (1).')
-        ->expectsOutputToContain('Pruned 1 activity record(s).')
+    expectPruneSummary(
+        $this->artisan('filament-logger:prune'),
+        'Pruning scope: older than 30 day(s); matching log names: all log names; excluded log names: Notification.',
+        'Matching records by log name: Access (1).',
+        'Pruned 1 activity record(s).',
+    )
         ->assertSuccessful();
 
     expect(Activity::query()->orderBy('id')->pluck('description')->all())

--- a/tests/Feature/PruneActivitiesCommandTest.php
+++ b/tests/Feature/PruneActivitiesCommandTest.php
@@ -13,6 +13,11 @@ function createPruneActivity(string $logName, string $description, string $event
     ]);
 }
 
+function pruneActivitiesCommand(\MrAdder\FilamentLogger\Tests\TestCase $test, array $commandOptions = [])
+{
+    return $test->artisan('filament-logger:prune', $commandOptions);
+}
+
 function expectPruneSummary($command, string $scopeSummary, string $breakdownSummary, string $resultSummary)
 {
     return $command
@@ -30,7 +35,7 @@ it('prunes only matching old activity records', function () {
     createPruneActivity('Access', 'Recent access record', 'Login', 5);
 
     expectPruneSummary(
-        $this->artisan('filament-logger:prune'),
+        pruneActivitiesCommand($this),
         'Pruning scope: older than 30 day(s); matching log names: Access; excluded log names: none.',
         'Matching records by log name: Access (1).',
         'Pruned 1 activity record(s).',
@@ -50,7 +55,7 @@ it('supports dry-run pruning', function () {
     createPruneActivity('Access', 'Old access record', 'Login', 40);
 
     expectPruneSummary(
-        $this->artisan('filament-logger:prune', ['--dry-run' => true]),
+        pruneActivitiesCommand($this, ['--dry-run' => true]),
         'Pruning scope: older than 30 day(s); matching log names: all log names; excluded log names: none.',
         'Matching records by log name: Access (1).',
         'Dry run: 1 activity record(s) would be pruned.',
@@ -68,7 +73,7 @@ it('reports when nothing matches pruning rules', function () {
     createPruneActivity('Notification', 'Old notification record', 'Notification Sent', 40);
 
     expectPruneSummary(
-        $this->artisan('filament-logger:prune'),
+        pruneActivitiesCommand($this),
         'Pruning scope: older than 30 day(s); matching log names: Access; excluded log names: Notification.',
         'Matching records by log name: none.',
         'No activity records matched the pruning rules.',
@@ -86,7 +91,7 @@ it('reports real prune summaries with excluded log names', function () {
     createPruneActivity('Notification', 'Old notification record', 'Notification Sent', 40);
 
     expectPruneSummary(
-        $this->artisan('filament-logger:prune'),
+        pruneActivitiesCommand($this),
         'Pruning scope: older than 30 day(s); matching log names: all log names; excluded log names: Notification.',
         'Matching records by log name: Access (1).',
         'Pruned 1 activity record(s).',

--- a/tests/Feature/PruneActivitiesCommandTest.php
+++ b/tests/Feature/PruneActivitiesCommandTest.php
@@ -13,6 +13,13 @@ function createPruneActivity(string $logName, string $description, string $event
     ]);
 }
 
+function setPruneConfig(int $days = 365, array $only = [], array $except = []): void
+{
+    config()->set('filament-logger.pruning.days', $days);
+    config()->set('filament-logger.pruning.only', $only);
+    config()->set('filament-logger.pruning.except', $except);
+}
+
 function pruneActivitiesCommand(\MrAdder\FilamentLogger\Tests\TestCase $test, array $commandOptions = [])
 {
     return $test->artisan('filament-logger:prune', $commandOptions);
@@ -26,12 +33,32 @@ function expectPruneSummary($command, string $scopeSummary, string $breakdownSum
         ->expectsOutputToContain($resultSummary);
 }
 
-it('prunes only matching old activity records', function () {
-    config()->set('filament-logger.pruning.days', 30);
-    config()->set('filament-logger.pruning.only', ['Access']);
+function seedOldAccessRecord(string $description, int $daysAgo = 40): void
+{
+    createPruneActivity('Access', $description, 'Login', $daysAgo);
+}
 
-    createPruneActivity('Access', 'Old access record', 'Login', 40);
-    createPruneActivity('Notification', 'Old notification record', 'Notification Sent', 40);
+function seedOldNotificationRecord(string $description, int $daysAgo = 40): void
+{
+    createPruneActivity('Notification', $description, 'Notification Sent', $daysAgo);
+}
+
+function assertActivityDescriptions(array $descriptions): void
+{
+    expect(Activity::query()->orderBy('id')->pluck('description')->all())
+        ->toBe($descriptions);
+}
+
+function assertActivityCount(int $count): void
+{
+    expect(Activity::query()->count())->toBe($count);
+}
+
+it('prunes only matching old activity records', function () {
+    setPruneConfig(30, ['Access']);
+
+    seedOldAccessRecord('Old access record');
+    seedOldNotificationRecord('Old notification record');
     createPruneActivity('Access', 'Recent access record', 'Login', 5);
 
     expectPruneSummary(
@@ -42,17 +69,16 @@ it('prunes only matching old activity records', function () {
     )
         ->assertSuccessful();
 
-    expect(Activity::query()->orderBy('id')->pluck('description')->all())
-        ->toBe([
-            'Old notification record',
-            'Recent access record',
-        ]);
+    assertActivityDescriptions([
+        'Old notification record',
+        'Recent access record',
+    ]);
 });
 
 it('supports dry-run pruning', function () {
-    config()->set('filament-logger.pruning.days', 30);
+    setPruneConfig(30);
 
-    createPruneActivity('Access', 'Old access record', 'Login', 40);
+    seedOldAccessRecord('Old access record');
 
     expectPruneSummary(
         pruneActivitiesCommand($this, ['--dry-run' => true]),
@@ -62,15 +88,13 @@ it('supports dry-run pruning', function () {
     )
         ->assertSuccessful();
 
-    expect(Activity::query()->count())->toBe(1);
+    assertActivityCount(1);
 });
 
 it('reports when nothing matches pruning rules', function () {
-    config()->set('filament-logger.pruning.days', 30);
-    config()->set('filament-logger.pruning.only', ['Access']);
-    config()->set('filament-logger.pruning.except', ['Notification']);
+    setPruneConfig(30, ['Access'], ['Notification']);
 
-    createPruneActivity('Notification', 'Old notification record', 'Notification Sent', 40);
+    seedOldNotificationRecord('Old notification record');
 
     expectPruneSummary(
         pruneActivitiesCommand($this),
@@ -80,15 +104,14 @@ it('reports when nothing matches pruning rules', function () {
     )
         ->assertSuccessful();
 
-    expect(Activity::query()->count())->toBe(1);
+    assertActivityCount(1);
 });
 
 it('reports real prune summaries with excluded log names', function () {
-    config()->set('filament-logger.pruning.days', 30);
-    config()->set('filament-logger.pruning.except', ['Notification']);
+    setPruneConfig(30, [], ['Notification']);
 
-    createPruneActivity('Access', 'Old access record', 'Login', 40);
-    createPruneActivity('Notification', 'Old notification record', 'Notification Sent', 40);
+    seedOldAccessRecord('Old access record');
+    seedOldNotificationRecord('Old notification record');
 
     expectPruneSummary(
         pruneActivitiesCommand($this),
@@ -98,8 +121,7 @@ it('reports real prune summaries with excluded log names', function () {
     )
         ->assertSuccessful();
 
-    expect(Activity::query()->orderBy('id')->pluck('description')->all())
-        ->toBe([
-            'Old notification record',
-        ]);
+    assertActivityDescriptions([
+        'Old notification record',
+    ]);
 });

--- a/tests/Feature/PruneActivitiesCommandTest.php
+++ b/tests/Feature/PruneActivitiesCommandTest.php
@@ -74,7 +74,7 @@ it('prunes only matching old activity records', function () {
         ->assertSuccessful();
 
     assertActivityDescriptions([
-        'Old notification record',
+        PRUNE_NOTIFICATION_RECORD_DESCRIPTION,
         'Recent access record',
     ]);
 });
@@ -126,6 +126,6 @@ it('reports real prune summaries with excluded log names', function () {
         ->assertSuccessful();
 
     assertActivityDescriptions([
-        'Old notification record',
+        PRUNE_NOTIFICATION_RECORD_DESCRIPTION,
     ]);
 });

--- a/tests/Feature/PruneActivitiesCommandTest.php
+++ b/tests/Feature/PruneActivitiesCommandTest.php
@@ -2,6 +2,10 @@
 
 use Spatie\Activitylog\Models\Activity;
 
+const PRUNE_ACCESS_RECORD_DESCRIPTION = 'Old access record';
+const PRUNE_NOTIFICATION_RECORD_DESCRIPTION = 'Old notification record';
+const PRUNE_ACCESS_BREAKDOWN_SUMMARY = 'Matching records by log name: Access (1).';
+
 function createPruneActivity(string $logName, string $description, string $event, int $daysAgo): void
 {
     Activity::query()->create([
@@ -57,14 +61,14 @@ function assertActivityCount(int $count): void
 it('prunes only matching old activity records', function () {
     setPruneConfig(30, ['Access']);
 
-    seedOldAccessRecord('Old access record');
-    seedOldNotificationRecord('Old notification record');
+    seedOldAccessRecord(PRUNE_ACCESS_RECORD_DESCRIPTION);
+    seedOldNotificationRecord(PRUNE_NOTIFICATION_RECORD_DESCRIPTION);
     createPruneActivity('Access', 'Recent access record', 'Login', 5);
 
     expectPruneSummary(
         pruneActivitiesCommand($this),
         'Pruning scope: older than 30 day(s); matching log names: Access; excluded log names: none.',
-        'Matching records by log name: Access (1).',
+        PRUNE_ACCESS_BREAKDOWN_SUMMARY,
         'Pruned 1 activity record(s).',
     )
         ->assertSuccessful();
@@ -78,12 +82,12 @@ it('prunes only matching old activity records', function () {
 it('supports dry-run pruning', function () {
     setPruneConfig(30);
 
-    seedOldAccessRecord('Old access record');
+    seedOldAccessRecord(PRUNE_ACCESS_RECORD_DESCRIPTION);
 
     expectPruneSummary(
         pruneActivitiesCommand($this, ['--dry-run' => true]),
         'Pruning scope: older than 30 day(s); matching log names: all log names; excluded log names: none.',
-        'Matching records by log name: Access (1).',
+        PRUNE_ACCESS_BREAKDOWN_SUMMARY,
         'Dry run: 1 activity record(s) would be pruned.',
     )
         ->assertSuccessful();
@@ -94,7 +98,7 @@ it('supports dry-run pruning', function () {
 it('reports when nothing matches pruning rules', function () {
     setPruneConfig(30, ['Access'], ['Notification']);
 
-    seedOldNotificationRecord('Old notification record');
+    seedOldNotificationRecord(PRUNE_NOTIFICATION_RECORD_DESCRIPTION);
 
     expectPruneSummary(
         pruneActivitiesCommand($this),
@@ -110,13 +114,13 @@ it('reports when nothing matches pruning rules', function () {
 it('reports real prune summaries with excluded log names', function () {
     setPruneConfig(30, [], ['Notification']);
 
-    seedOldAccessRecord('Old access record');
-    seedOldNotificationRecord('Old notification record');
+    seedOldAccessRecord(PRUNE_ACCESS_RECORD_DESCRIPTION);
+    seedOldNotificationRecord(PRUNE_NOTIFICATION_RECORD_DESCRIPTION);
 
     expectPruneSummary(
         pruneActivitiesCommand($this),
         'Pruning scope: older than 30 day(s); matching log names: all log names; excluded log names: Notification.',
-        'Matching records by log name: Access (1).',
+        PRUNE_ACCESS_BREAKDOWN_SUMMARY,
         'Pruned 1 activity record(s).',
     )
         ->assertSuccessful();


### PR DESCRIPTION
## Summary

Fixes #20 

This PR improves pruning output so users can understand what would be removed or was removed during retention runs. It adds clearer dry-run summaries, a per-log-name breakdown, and more explicit reporting while keeping pruning semantics unchanged.

## Changes

- Added a pruning scope summary that reports:
  - retention age
  - matching log names
  - excluded log names
- Added a per-log-name breakdown of matching records.
- Made dry-run output explicit (`Dry run: ... would be pruned.`).
- Kept real prune output backward-compatible.
- Expanded pruning command tests to cover:
  - filtered pruning
  - dry-run reporting
  - excluded log names
  - no-match output

## Testing

- `php vendor/bin/pest tests/Feature/PruneActivitiesCommandTest.php --no-coverage -vvv`
- `php vendor/bin/phpstan analyse --memory-limit=512M --error-format=github`

## Screenshots

- N/A

## Checklist

- [x] Linked the related issue, or explained why there is no linked issue
- [x] Updated documentation or configuration where needed
- [x] Added or updated tests where needed
- [x] Verified the relevant checks locally
- [x] Noted any breaking changes or follow-up work below

## Breaking Changes / Follow-Up

- None