### PR TITLE
fix the defaultHeaderWidgets conflict with the Filament framework

### DIFF
--- a/src/Resources/ActivityResource/Pages/BaseListActivities.php
+++ b/src/Resources/ActivityResource/Pages/BaseListActivities.php
@@ -104,13 +104,13 @@ abstract class BaseListActivities extends ListRecords
      */
     protected function getHeaderWidgets(): array
     {
-        return ActivityDisplay::resolveWidgets($this->defaultHeaderWidgets());
+        return ActivityDisplay::resolveWidgets($this->defaultDashboardWidgets());
     }
 
     /**
      * @return array<int, mixed>
      */
-    protected function defaultHeaderWidgets(): array
+    protected function defaultDashboardWidgets(): array
     {
         if (! config('filament-logger.dashboard.enabled', true)) {
             return [];


### PR DESCRIPTION
Hi Daniel, first of all, thank you for creating this nice package!

## Summary

When upgrading from v1.4.1 to 1.6.0, I noticed the ActivityResource gave a 500: 
`Filament\Pages\Page::headerWidgets(): Argument #1 ($schema) must be of type Filament\Schemas\Schema, array given, called in /var/www/html/vendor/filament/schemas/src/Concerns/InteractsWithSchemas.php on line 306`
The issue is that the defaultHeaderWidgets conflicts with the default Filament function. Renaming the function fixed it for me.

## Changes
I changed the function name of defaultHeaderWidgets() to defaultDashboardWidgets() in  `src/Resources/ActivityResource/Pages/BaseListActivities.php`

## Testing
I tested it in my application + the tests still run
